### PR TITLE
Шишкарев Андрей. Лабораторная работа 1. Clang AST. Вариант 3.

### DIFF
--- a/.github/deadline.py
+++ b/.github/deadline.py
@@ -9,7 +9,7 @@ def main():
     moscow_tz = ZoneInfo("Europe/Moscow")
     current_date = datetime.now(moscow_tz)
     deadline_date = {
-        "lab:clang": datetime(2025, 6, 1, hour=19, tzinfo=moscow_tz),
+        "lab:clang": datetime(2025, 3, 19, hour=19, tzinfo=moscow_tz),
         "lab:llvm ir": datetime(2025, 6, 1, hour=19, tzinfo=moscow_tz),
         "lab:backend": datetime(2025, 6, 1, hour=19, tzinfo=moscow_tz),
         "lab:mlir": datetime(2025, 6, 1, hour=19, tzinfo=moscow_tz),

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -12,5 +12,8 @@ tests:
  - "llvm/test/compiler-course/**"
  - "mlir/test/compiler-course/**"
 
+docs:
+ - "README.md"
+
 ci:
  - ".github/**"

--- a/.github/workflows/compiler-course-tidy.yml
+++ b/.github/workflows/compiler-course-tidy.yml
@@ -6,12 +6,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
     - name: Install clang-format
       run: |
         sudo apt-get install -y clang-format
     - name: Run clang-format
       run: |
-        git-clang-format --diff `git merge-base ${GITHUB_SHA} ${GITHUB_BASE_REF}`
+        git-clang-format --diff `git merge-base ${GITHUB_SHA} origin/${GITHUB_BASE_REF}` ${GITHUB_SHA} 2>&1 | tee log.txt
+        exit `grep -c diff log.txt`
   clang-tidy:
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
     - [LLVM][llvm]
     - [MLIR][mlir]
     - [Clang][clang]
+    - [FileCheck][filecheck]
     - [Official YouTube channel LLVM][youtube_llvm]
 
 <!-- LINKS -->
@@ -26,6 +27,7 @@
 [llvm]: https://llvm.org/
 [mlir]: https://mlir.llvm.org/
 [clang]: https://clang.llvm.org/
+[filecheck]: https://llvm.org/docs/CommandGuide/FileCheck.html
 [youtube_llvm]: https://www.youtube.com/@LLVMPROJ
 
 # What is LLVM?
@@ -52,7 +54,7 @@ Recommended OS - Linux (WSL).
 2. Clone local fork
 ```bash
 git clone https://github.com/<your-github-name>/compiler-course-2025.git
-cd llvm/
+cd compiler-course-2025/
 git checkout -b <name-your-branch>
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,32 @@
 # Compiler course 2025
 
-[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/llvm/llvm-project/badge)](https://securityscorecards.dev/viewer/?uri=github.com/llvm/llvm-project)
-[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/8273/badge)](https://www.bestpractices.dev/projects/8273)
-[![libc++](https://github.com/llvm/llvm-project/actions/workflows/libcxx-build-and-test.yaml/badge.svg?branch=main&event=schedule)](https://github.com/llvm/llvm-project/actions/workflows/libcxx-build-and-test.yaml?query=event%3Aschedule)
+[![Build LLVM](https://github.com/NN-complr-tech/compiler-course-2025/actions/workflows/compiler-course-build.yml/badge.svg)](https://github.com/NN-complr-tech/compiler-course-2025/actions/workflows/compiler-course-build.yml)
+
+# Resources
+- [Telegram сhat][chat]
+- [Telegram сhannel][channel]
+- [Tasks and results][results]
+- Materials
+    - [Lecture recordings][recording]
+    - [Lecture presentations][lecture]
+    - [LLVM][llvm]
+    - [MLIR][mlir]
+    - [Clang][clang]
+    - [Official YouTube channel LLVM][youtube_llvm]
+
+<!-- LINKS -->
+<!-- Tasks and results -->
+[results]: https://docs.google.com/spreadsheets/d/1LiZ5FMd5t61yoGdnpANTFpzqtKD_ejtvLl1cHKZxvXQ/edit?usp=sharing
+<!-- Contacts -->
+[channel]: https://t.me/+TPntKPD8z0E3OWJi
+[chat]: https://t.me/+JG3n1jeSAiIxZjMy
+<!-- Materials -->
+[recording]: https://disk.yandex.ru/d/52gu5vJTSt1VFg
+[lecture]: https://github.com/NN-complr-tech/Complr-course-lectures
+[llvm]: https://llvm.org/
+[mlir]: https://mlir.llvm.org/
+[clang]: https://clang.llvm.org/
+[youtube_llvm]: https://www.youtube.com/@LLVMPROJ
 
 # What is LLVM?
 LLLVM is a set of compiler and toolchain technologies that can be used to develop a frontend for any programming language and a backend for any instruction set architecture. LLVM is designed around a language-independent intermediate representation (IR) that serves as a portable, high-level assembly language that can be optimized with a variety of transformations over multiple passes. The name LLVM originally stood for Low Level Virtual Machine, though the project has expanded and the name is no longer officially an initialism.
@@ -105,26 +129,3 @@ For one test
 ```bash
 ./build/bin/llvm-lit -v /path/to/test_file
 ```
-# 6. Resources
-- [Telegram сhat][chat]
-- [Telegram сhannel][channel]
-- [Tasks and results][results]
-- Materials
-    - [Lectures][lecture]
-    - [LLVM][llvm]
-    - [MLIR][mlir]
-    - [Clang][clang]
-    - [Official YouTube channel LLVM][youtube_llvm]
-
-<!-- LINKS -->
-<!-- Tasks and results -->
-[results]: https://docs.google.com/spreadsheets/d/1LiZ5FMd5t61yoGdnpANTFpzqtKD_ejtvLl1cHKZxvXQ/edit?usp=sharing
-<!-- Contacts -->
-[channel]: https://t.me/+TPntKPD8z0E3OWJi
-[chat]: https://t.me/+JG3n1jeSAiIxZjMy
-<!-- Materials -->
-[lecture]: https://github.com/NN-complr-tech/Complr-course-lectures
-[llvm]: https://llvm.org/
-[mlir]: https://mlir.llvm.org/
-[clang]: https://clang.llvm.org/
-[youtube_llvm]: https://www.youtube.com/@LLVMPROJ

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Recommended OS - Linux (WSL).
 1. Create fork this repository
 2. Clone local fork
 ```bash
-git clone https://github.com/<your-github-name>/llvm.git
+git clone https://github.com/<your-github-name>/compiler-course-2025.git
 cd llvm/
 git checkout -b <name-your-branch>
 ```

--- a/clang/compiler-course/Kholin_K_prefixes/CMakeLists.txt
+++ b/clang/compiler-course/Kholin_K_prefixes/CMakeLists.txt
@@ -1,0 +1,18 @@
+set(Title "PrefixesPlugin")
+set(Student "KholinKirill")
+set(Group "FIIT3")
+set(TARGET_NAME "${Title}_${Student}_${Group}_ClangAST")
+
+file(GLOB_RECURSE SOURCES *.cpp *.h *.hpp)
+add_llvm_library(${TARGET_NAME} MODULE ${SOURCES} PLUGIN_TOOL clang)
+
+if(WIN32 OR CYGWIN)
+    set(LLVM_LINK_COMPONENTS Support)
+    clang_target_link_libraries(${TARGET_NAME} PRIVATE
+        clangAST
+        clangBasic
+        clangFrontend
+    )
+endif()
+
+set(CLANG_TEST_DEPS "${TARGET_NAME}" ${CLANG_TEST_DEPS} PARENT_SCOPE)

--- a/clang/compiler-course/Kholin_K_prefixes/Kholin_K_prefixes_plugin.cpp
+++ b/clang/compiler-course/Kholin_K_prefixes/Kholin_K_prefixes_plugin.cpp
@@ -1,0 +1,105 @@
+#include "clang/AST/ASTConsumer.h"
+#include "clang/AST/RecursiveASTVisitor.h"
+#include "clang/Frontend/CompilerInstance.h"
+#include "clang/Frontend/FrontendPluginRegistry.h"
+#include "clang/Rewrite/Core/Rewriter.h"
+#include "llvm/Support/raw_ostream.h"
+#include <fstream>
+#include <optional>
+#include <set>
+
+using namespace clang;
+
+class FindNamedClassVisitor
+    : public RecursiveASTVisitor<FindNamedClassVisitor> {
+public:
+  explicit FindNamedClassVisitor(ASTContext *Context, Rewriter &R)
+      : Context(Context), Rewrite(R) {}
+
+  std::optional<std::string> getVarPrefix(const VarDecl *Decl) {
+    if (Decl->isStaticLocal()) {
+      return "static_";
+    } else if (Decl->isFileVarDecl()) {
+      return "global_";
+    } else if (isa<ParmVarDecl>(Decl)) {
+      return "param_";
+    } else if (Decl->isLocalVarDecl()) {
+      return "local_";
+    }
+    return std::nullopt;
+  }
+
+  void renameVariable(Decl *Decl, SourceLocation StartLocation) {
+    if (!Decl) return;
+
+    std::optional<std::string> VarPrefix = getVarPrefix(cast<VarDecl>(Decl));
+    if (!VarPrefix.has_value()) return;
+
+    std::string NewID = VarPrefix.value() + cast<VarDecl>(Decl)->getNameAsString();
+    SourceLocation EndLocation =
+        StartLocation.getLocWithOffset(cast<VarDecl>(Decl)->getNameAsString().length());
+    Rewrite.ReplaceText(SourceRange(StartLocation, EndLocation), NewID);
+
+    FullSourceLoc FullLocation = Context->getFullLoc(StartLocation);
+    if (FullLocation.isValid()) {
+      llvm::outs() << "Found variable: " << cast<VarDecl>(Decl)->getNameAsString() << " -> "
+                   << NewID << " at " << FullLocation.getSpellingLineNumber() << ":"
+                   << FullLocation.getSpellingColumnNumber() << "\n";
+    }
+  }
+
+  bool VisitVarDecl(VarDecl *Decl) {
+    if (!Decl) return false;
+    renameVariable(Decl, Decl->getLocation());
+    return true;
+  }
+
+  bool VisitDeclRefExpr(DeclRefExpr *Expr) {
+    if (!Expr) return false;
+
+    VarDecl *Decl = dyn_cast<VarDecl>(Expr->getDecl());
+
+    renameVariable(Decl, Expr->getLocation());
+    return true;
+  }
+
+private:
+  ASTContext *Context;
+  Rewriter &Rewrite;
+};
+
+class FindNamedClassConsumer : public clang::ASTConsumer {
+public:
+  explicit FindNamedClassConsumer(ASTContext *Context, Rewriter &R)
+      : Visitor(Context, R) {}
+
+  void HandleTranslationUnit(ASTContext &Context) override {
+    Visitor.TraverseDecl(Context.getTranslationUnitDecl());
+  }
+
+private:
+  FindNamedClassVisitor Visitor;
+};
+
+class FindNamedClassAction : public clang::PluginASTAction {
+public:
+  std::unique_ptr<clang::ASTConsumer>
+  CreateASTConsumer(CompilerInstance &Compiler,
+                    llvm::StringRef InFile) override {
+    m_rewriter.setSourceMgr(Compiler.getSourceManager(),
+                            Compiler.getLangOpts());
+    return std::make_unique<FindNamedClassConsumer>(&Compiler.getASTContext(),
+                                                    m_rewriter);
+  }
+
+  bool ParseArgs(const CompilerInstance &CI,
+                 const std::vector<std::string> &Args) override {
+    return true;
+  }
+
+private:
+  Rewriter m_rewriter;
+};
+
+static clang::FrontendPluginRegistry::Add<FindNamedClassAction>
+    X("PrefixesPlugin_KholinKirill_FIIT3_ClangAST", "set prefixes variables");

--- a/clang/compiler-course/Shurigin_S_FI1_ClangAst_var4/CMakeLists.txt
+++ b/clang/compiler-course/Shurigin_S_FI1_ClangAst_var4/CMakeLists.txt
@@ -1,0 +1,18 @@
+set(Title "ClangAST_1")
+set(Student "ShuriginS")
+set(Group "FIIT1")
+set(TARGET_NAME "${Title}_${Student}_${Group}_ClangAST")
+
+file(GLOB_RECURSE SOURCES *.cpp *.h *.hpp)
+add_llvm_library(${TARGET_NAME} MODULE ${SOURCES} PLUGIN_TOOL clang)
+
+if(WIN32 OR CYGWIN)
+    set(LLVM_LINK_COMPONENTS Support)
+    clang_target_link_libraries(${TARGET_NAME} PRIVATE
+        clangAST
+        clangBasic
+        clangFrontend
+    )
+endif()
+
+set(CLANG_TEST_DEPS "${TARGET_NAME}" ${CLANG_TEST_DEPS} PARENT_SCOPE)

--- a/clang/compiler-course/Shurigin_S_FI1_ClangAst_var4/ShuriginAST.cpp
+++ b/clang/compiler-course/Shurigin_S_FI1_ClangAst_var4/ShuriginAST.cpp
@@ -1,0 +1,130 @@
+﻿#include "clang/AST/ASTConsumer.h"
+#include "clang/AST/RecursiveASTVisitor.h"
+#include "clang/Frontend/CompilerInstance.h"
+#include "clang/Frontend/FrontendPluginRegistry.h"
+#include "clang/Rewrite/Core/Rewriter.h"
+#include "llvm/Support/raw_ostream.h"
+#include <unordered_map>
+
+namespace {
+
+class ExampleVisitor final : public clang::RecursiveASTVisitor<ExampleVisitor> {
+public:
+  explicit ExampleVisitor(clang::ASTContext *Context, clang::Rewriter &Rewriter)
+      : MRewriter(Rewriter) {}
+
+  bool VisitVarDecl(clang::VarDecl *Var) {
+    if (Var->getName().empty()) {
+      return true;
+    }
+
+    std::string Prefix;
+    if (Var->isStaticLocal()) {
+      Prefix = "static_";
+    } else if (Var->isLocalVarDecl()) {
+      Prefix = "local_";
+    } else if (Var->hasGlobalStorage()) {
+      Prefix = "global_";
+    }
+
+    if (!Prefix.empty()) {
+      std::string OldName = Var->getName().str();
+      if (OldName.find(Prefix) != 0) {
+        std::string NewName = Prefix + OldName;
+        MRenamedVars[OldName] = NewName;
+        clang::SourceLocation Loc = Var->getLocation();
+        MRewriter.ReplaceText(Loc, OldName.length(), NewName);
+      }
+    }
+    return true;
+  }
+
+  bool VisitParmVarDecl(clang::ParmVarDecl *Param) {
+    if (Param->getName().empty()) {
+      return true;
+    }
+
+    std::string OldName = Param->getName().str();
+    std::string NewName = "param_" + OldName;
+    MRenamedVars[OldName] = NewName;
+    MRewriter.ReplaceText(Param->getLocation(), OldName.size(), NewName);
+    return true;
+  }
+
+  bool VisitDeclRefExpr(clang::DeclRefExpr *Expr) {
+    clang::ValueDecl *Decl = Expr->getDecl();
+    if (Decl->getName().empty()) {
+      return true;
+    }
+
+    std::string OldName = Decl->getName().str();
+
+    if (llvm::isa<clang::FunctionDecl>(Decl)) {
+      return true;
+    }
+
+    if (auto VD = llvm::dyn_cast<clang::VarDecl>(Decl)) {
+      VD = VD->getCanonicalDecl();
+
+      if (VD->hasExternalStorage()) {
+        std::string NewName = "global_" + OldName;
+        MRenamedVars[OldName] = NewName;
+        MRewriter.ReplaceText(Expr->getLocation(), OldName.length(), NewName);
+        return true;
+      }
+    }
+
+    auto It = MRenamedVars.find(OldName);
+    if (It != MRenamedVars.end()) {
+      clang::SourceLocation Loc = Expr->getLocation();
+      MRewriter.ReplaceText(Loc, OldName.length(), It->second);
+    }
+    return true;
+  }
+
+private:
+  clang::Rewriter &MRewriter;
+  std::unordered_map<std::string, std::string> MRenamedVars;
+};
+
+class ExampleConsumer final : public clang::ASTConsumer {
+public:
+  explicit ExampleConsumer(clang::ASTContext *Context,
+                           clang::Rewriter &Rewriter)
+      : MRewriter(Rewriter), MVisitor(Context, Rewriter) {}
+
+  void HandleTranslationUnit(clang::ASTContext &Context) override {
+    MVisitor.TraverseDecl(Context.getTranslationUnitDecl());
+  }
+
+private:
+  clang::Rewriter &MRewriter;
+  ExampleVisitor MVisitor;
+};
+
+class ExampleAction final : public clang::PluginASTAction {
+public:
+  std::unique_ptr<clang::ASTConsumer>
+  CreateASTConsumer(clang::CompilerInstance &Ci, llvm::StringRef) override {
+    MRewriter.setSourceMgr(Ci.getSourceManager(), Ci.getLangOpts());
+    return std::make_unique<ExampleConsumer>(&Ci.getASTContext(), MRewriter);
+  }
+
+  bool ParseArgs(const clang::CompilerInstance &Ci,
+                 const std::vector<std::string> &Args) override {
+    return true;
+  }
+
+  void EndSourceFileAction() override {
+    MRewriter.getEditBuffer(MRewriter.getSourceMgr().getMainFileID())
+        .write(llvm::outs());
+  }
+
+private:
+  clang::Rewriter MRewriter;
+};
+
+} // namespace
+
+static clang::FrontendPluginRegistry::Add<ExampleAction>
+    X("ClangAST_1_ShuriginS_FIIT1_ClangAST", "Adds prefixes to variables");

--- a/clang/compiler-course/beskhmelnova_k_implicit_conversions/CMakeLists.txt
+++ b/clang/compiler-course/beskhmelnova_k_implicit_conversions/CMakeLists.txt
@@ -1,0 +1,18 @@
+set(Title "ClangAST_1")
+set(Student "BeskhmelnovaK")
+set(Group "FIIT1")
+set(TARGET_NAME "${Title}_${Student}_${Group}_ClangAST")
+
+file(GLOB_RECURSE SOURCES *.cpp *.h *.hpp)
+add_llvm_library(${TARGET_NAME} MODULE ${SOURCES} PLUGIN_TOOL clang)
+
+if(WIN32 OR CYGWIN)
+    set(LLVM_LINK_COMPONENTS Support)
+    clang_target_link_libraries(${TARGET_NAME} PRIVATE
+        clangAST
+        clangBasic
+        clangFrontend
+    )
+endif()
+
+set(CLANG_TEST_DEPS "${TARGET_NAME}" ${CLANG_TEST_DEPS} PARENT_SCOPE)

--- a/clang/compiler-course/beskhmelnova_k_implicit_conversions/beskhmelnova_k_implicit_conversions.cpp
+++ b/clang/compiler-course/beskhmelnova_k_implicit_conversions/beskhmelnova_k_implicit_conversions.cpp
@@ -1,0 +1,116 @@
+#include "clang/AST/ASTConsumer.h"
+#include "clang/AST/RecursiveASTVisitor.h"
+#include "clang/Frontend/CompilerInstance.h"
+#include "clang/Frontend/FrontendPluginRegistry.h"
+#include "llvm/Support/raw_ostream.h"
+#include <map>
+#include <vector>
+#include <algorithm>
+
+namespace {
+
+	class ImplicitCastVisitor final : public clang::RecursiveASTVisitor<ImplicitCastVisitor> {
+	public:
+		explicit ImplicitCastVisitor() = default;
+
+		bool VisitFunctionDecl(clang::FunctionDecl* Func) {
+			CurrentFunction = Func->getNameInfo().getName().getAsString();
+			return true;
+		}
+
+		bool VisitCXXConstructExpr(clang::CXXConstructExpr* Ctor) {
+			if (Ctor->getNumArgs() < 1) {
+				return true;
+			}
+
+			clang::QualType FromType = Ctor->getArg(0)->getType();
+			clang::QualType ToType = Ctor->getType();
+
+			if (FromType == ToType) {
+				return true;
+			}
+
+			CastList.emplace_back(CastEntry{ CurrentFunction, FromType.getAsString(), ToType.getAsString() });
+			return true;
+		}
+
+		clang::QualType getRealType(clang::QualType Type) {
+			Type = Type.getCanonicalType();
+			if (auto* TST = Type->getAs<clang::TypedefType>()) {
+				return TST->getDecl()->getUnderlyingType().getCanonicalType();
+			}
+			return Type;
+		}
+
+		bool VisitImplicitCastExpr(clang::ImplicitCastExpr* Cast) {
+			clang::CastKind Kind = Cast->getCastKind();
+			if (Kind == clang::CK_NoOp || Kind == clang::CK_LValueToRValue || Kind == clang::CK_FunctionToPointerDecay) {
+				return true;
+			}
+
+			clang::QualType FromType = getRealType(Cast->getSubExpr()->getType());
+			clang::QualType ToType = getRealType(Cast->getType());
+
+			if (FromType == ToType) {
+				return true;
+			}
+
+			CastList.emplace_back(CastEntry{ CurrentFunction, FromType.getAsString(), ToType.getAsString() });
+			return true;
+		}
+
+		void PrintResults() {
+			std::string LastFunction;
+			for (const auto& Entry : CastList) {
+				if (Entry.FunctionName != LastFunction) {
+					llvm::outs() << "Function " << Entry.FunctionName << "\n";
+					LastFunction = Entry.FunctionName;
+				}
+				llvm::outs() << Entry.getCastDescription() << ": 1\n";
+			}
+			llvm::outs() << "Total implicit conversions: " << CastList.size() << "\n";
+		}
+
+	private:
+		struct CastEntry {
+			std::string FunctionName;
+			std::string FromType;
+			std::string ToType;
+
+			std::string getCastDescription() const {
+				return FromType + " -> " + ToType;
+			}
+		};
+
+		std::string CurrentFunction;
+		std::vector<CastEntry> CastList;
+	};
+
+	class ImplicitCastConsumer final : public clang::ASTConsumer {
+	public:
+		explicit ImplicitCastConsumer() = default;
+
+		void HandleTranslationUnit(clang::ASTContext& Context) override {
+			Visitor.TraverseDecl(Context.getTranslationUnitDecl());
+			Visitor.PrintResults();
+		}
+
+	private:
+		ImplicitCastVisitor Visitor;
+	};
+
+	class ImplicitCastAction final : public clang::PluginASTAction {
+	public:
+		std::unique_ptr<clang::ASTConsumer> CreateASTConsumer(clang::CompilerInstance& CI, llvm::StringRef) override {
+			return std::make_unique<ImplicitCastConsumer>();
+		}
+
+		bool ParseArgs(const clang::CompilerInstance& CI, const std::vector<std::string>& Args) override {
+			return true;
+		}
+	};
+
+} // namespace
+
+static clang::FrontendPluginRegistry::Add<ImplicitCastAction>
+X("ClangAST_1_BeskhmelnovaK_FIIT1_ClangAST", "Counts implicit type conversions");

--- a/clang/compiler-course/chistov_a_user_data_type/CMakeLists.txt
+++ b/clang/compiler-course/chistov_a_user_data_type/CMakeLists.txt
@@ -1,0 +1,18 @@
+set(Title "PrintData")
+set(Student "Chistov_Alexey")
+set(Group "FIIT1")
+set(TARGET_NAME "${Title}_${Student}_${Group}_ClangAST")
+
+file(GLOB_RECURSE SOURCES *.cpp *.h *.hpp)
+add_llvm_library(${TARGET_NAME} MODULE ${SOURCES} PLUGIN_TOOL clang)
+
+if(WIN32 OR CYGWIN)
+    set(LLVM_LINK_COMPONENTS Support)
+    clang_target_link_libraries(${TARGET_NAME} PRIVATE
+        clangAST
+        clangBasic
+        clangFrontend
+    )
+endif()
+
+set(CLANG_TEST_DEPS "${TARGET_NAME}" ${CLANG_TEST_DEPS} PARENT_SCOPE)

--- a/clang/compiler-course/chistov_a_user_data_type/chistov_a_user_data_type_plugin.cpp
+++ b/clang/compiler-course/chistov_a_user_data_type/chistov_a_user_data_type_plugin.cpp
@@ -1,0 +1,119 @@
+#include "clang/AST/ASTConsumer.h"
+#include "clang/AST/RecursiveASTVisitor.h"
+#include "clang/Frontend/CompilerInstance.h"
+#include "clang/Frontend/FrontendPluginRegistry.h"
+#include "llvm/Support/raw_ostream.h"
+
+namespace {
+class PrintDataVisitor final : public clang::RecursiveASTVisitor<PrintDataVisitor> {
+  clang::ASTContext *class_context_;
+
+  std::string AccessSpecifierToString(clang::AccessSpecifier accessSpecifier) {
+    switch (accessSpecifier) {
+      case clang::AS_public:
+        return "public";
+      case clang::AS_protected:
+        return "protected";
+      case clang::AS_private:
+        return "private";
+      default:
+        llvm::errs() << "Error: Unknown access specifier\n";
+        return "unknown access specifier";
+    }
+  }
+
+  void PrintMember(const clang::ValueDecl *member) {
+    auto &os = llvm::outs();
+    os << "| |_ " << member->getNameAsString() << ' ';
+    os << '(';
+
+    if (const auto *method = llvm::dyn_cast<clang::CXXMethodDecl>(member)) {
+      os << method->getReturnType().getAsString();
+      os << '|' << AccessSpecifierToString(member->getAccess());
+      if (method->isStatic()) {
+        os << "|static";
+      }
+      if (method->isVirtual()) {
+        os << "|virtual";
+      }
+      if (method->isOverloadedOperator()) {
+        os << "|override";
+      }
+      if (method->isPureVirtual()) {
+        os << "|pure";
+      }
+    } else {
+      os << member->getType().getAsString() << '|'
+         << AccessSpecifierToString(member->getAccess());
+    }
+
+    os << ")\n";
+  }
+
+public:
+  explicit PrintDataVisitor(clang::ASTContext *context) : class_context_(context) {}
+
+  bool VisitCXXRecordDecl(clang::CXXRecordDecl *declaration) {
+    auto &os = llvm::outs();
+    os << declaration->getNameAsString()
+       << (declaration->isStruct() ? "(struct" : "(class")
+       << (declaration->isTemplated() ? "|template)" : ")") << '\n';
+
+    if (!declaration->bases().empty()) {
+      for (const auto &base : declaration->bases()) {
+        if (auto *baseDecl = base.getType()->getAsCXXRecordDecl()) {
+          clang::AccessSpecifier accessSpecifier = base.getAccessSpecifier();
+          os << declaration->getName() << " -> "
+             << AccessSpecifierToString(accessSpecifier) << " "
+             << baseDecl->getName() << "\n";
+        }
+      }
+    }
+
+    if (!declaration->field_empty()) {
+      os << "|_Fields\n";
+      for (const auto *decl : declaration->decls()) {
+        if (auto *field = llvm::dyn_cast<clang::FieldDecl>(decl)) {
+          PrintMember(field);
+        }
+      }
+    }
+
+    if (!declaration->methods().empty()) {
+      os << "|_Methods\n";
+      for (const auto *method : declaration->methods()) {
+        PrintMember(method);
+      }
+    }
+    os << '\n';
+    return true;
+  }
+};
+
+class PrintDataConsumer final : public clang::ASTConsumer {
+public:
+  explicit PrintDataConsumer(clang::ASTContext *context) : visitor_(context) {}
+
+  void HandleTranslationUnit(clang::ASTContext &context) override {
+    visitor_.TraverseDecl(context.getTranslationUnitDecl());
+  }
+
+private:
+  PrintDataVisitor visitor_;
+};
+
+class PrintDataAction final : public clang::PluginASTAction {
+public:
+  std::unique_ptr<clang::ASTConsumer> CreateASTConsumer(clang::CompilerInstance &ci, llvm::StringRef) override {
+    return std::make_unique<PrintDataConsumer>(&ci.getASTContext());
+  }
+
+  bool ParseArgs(const clang::CompilerInstance &ci, const std::vector<std::string> &args) override {
+    return true;
+  }
+};
+
+} // namespace
+
+static clang::FrontendPluginRegistry::Add<PrintDataAction>
+    X("PrintDataPlugin", "Print information about a custom data type");

--- a/clang/compiler-course/kurakin_user_data_type/CMakeLists.txt
+++ b/clang/compiler-course/kurakin_user_data_type/CMakeLists.txt
@@ -1,0 +1,18 @@
+set(Title "UserDataTypePlugin")
+set(Student "Kurakin_Matvey")
+set(Group "FIIT1")
+set(TARGET_NAME "${Title}_${Student}_${Group}_ClangAST")
+
+file(GLOB_RECURSE SOURCES *.cpp *.h *.hpp)
+add_llvm_library(${TARGET_NAME} MODULE ${SOURCES} PLUGIN_TOOL clang)
+
+if(WIN32 OR CYGWIN)
+    set(LLVM_LINK_COMPONENTS Support)
+    clang_target_link_libraries(${TARGET_NAME} PRIVATE
+        clangAST
+        clangBasic
+        clangFrontend
+    )
+endif()
+
+set(CLANG_TEST_DEPS "${TARGET_NAME}" ${CLANG_TEST_DEPS} PARENT_SCOPE)

--- a/clang/compiler-course/kurakin_user_data_type/kurakin_user_data_type_plugin.cpp
+++ b/clang/compiler-course/kurakin_user_data_type/kurakin_user_data_type_plugin.cpp
@@ -1,0 +1,110 @@
+#include "clang/AST/ASTConsumer.h"
+#include "clang/AST/RecursiveASTVisitor.h"
+#include "clang/Frontend/CompilerInstance.h"
+#include "clang/Frontend/FrontendPluginRegistry.h"
+#include "llvm/Support/raw_ostream.h"
+#include "llvm/ADT/STLExtras.h"
+
+namespace {
+
+std::string getAccessModifier(clang::AccessSpecifier am){
+  if(am == clang::AS_public) return "|public";
+  else if(am == clang::AS_private) return "|private";
+  else if(am == clang::AS_protected) return "|protected";
+  return "";
+}
+
+class UserDataTypeVisitor final : public clang::RecursiveASTVisitor<UserDataTypeVisitor> {
+public:
+  explicit UserDataTypeVisitor(clang::ASTContext *context) : m_context(context) {}
+  bool VisitCXXRecordDecl(clang::CXXRecordDecl *rd) {
+    auto &os = llvm::outs();
+
+    os << rd->getNameAsString();
+    if(rd->getNumBases()) {
+      os << " -> ";
+      llvm::interleave(
+        rd->bases(),
+        os,
+        [&](const clang::CXXBaseSpecifier &x) { 
+          os << x.getType().getAsString(); 
+        },
+        ","
+      );
+    }
+    os << "\n";
+
+    os << "|_Fields\n";
+    for(const auto &f : rd->fields()) {
+      os << "| |_ " << f->getName() << " (" << f->getType().getAsString();
+      os << getAccessModifier(f->getAccess());
+      os << ")\n";
+    }
+    if(rd->fields().empty())
+      os << "| |_ (has no fields)\n";
+
+    os << "|\n";
+
+    os << "|_Methods\n";
+    for(const auto &m : rd->methods()) {
+      if(m->isImplicit()) continue;
+
+      os << "| |_ " << m->getNameAsString() << " (" << m->getReturnType().getAsString() << "(";
+      if(m->getNumParams()) {
+        llvm::interleave(
+          m->parameters(),
+          os,
+          [&](const clang::ParmVarDecl* x) {
+            os << x->getType().getAsString();
+          },
+          ","
+        );
+      }
+      os << ")";
+      os << getAccessModifier(m->getAccess());
+
+      if(m->hasAttr<clang::OverrideAttr>()) os << "|override";
+      else if(m->isVirtual()) os << "|virtual";
+      if(m->isPureVirtual()) os << "|pure";
+      if(m->isStatic()) os << "|static";
+
+      os << ")\n";
+    }
+    if(rd->methods().empty())
+      os << "| |_ (has no methods)\n";
+
+    return true;
+  }
+
+private:
+  clang::ASTContext *m_context;
+};
+
+class UserDataTypeConsumer final : public clang::ASTConsumer {
+public:
+  explicit UserDataTypeConsumer(clang::ASTContext *context) : m_visitor(context) {}
+
+  void HandleTranslationUnit(clang::ASTContext &context) override {
+    m_visitor.TraverseDecl(context.getTranslationUnitDecl());
+  }
+
+private:
+  UserDataTypeVisitor m_visitor;
+};
+
+class UserDataTypeAction final : public clang::PluginASTAction {
+public:
+  std::unique_ptr<clang::ASTConsumer>
+  CreateASTConsumer(clang::CompilerInstance &ci, llvm::StringRef) override {
+    return std::make_unique<UserDataTypeConsumer>(&ci.getASTContext());
+  }
+
+  bool ParseArgs(const clang::CompilerInstance &ci,
+                 const std::vector<std::string> &args) override {
+    return true;
+  }
+};
+} // namespace
+
+static clang::FrontendPluginRegistry::Add<UserDataTypeAction>
+    X("UserDataTypePlugin_Kurakin_Matvey_FIIT1_ClangAST", "Print information about the user's data type");

--- a/clang/compiler-course/lopatin_i_user_data_type/CMakeLists.txt
+++ b/clang/compiler-course/lopatin_i_user_data_type/CMakeLists.txt
@@ -1,0 +1,18 @@
+set(Title "UserDataTypePlugin")
+set(Student "LopatinIlya")
+set(Group "FIIT3")
+set(TARGET_NAME "${Title}_${Student}_${Group}_ClangAST")
+
+file(GLOB_RECURSE SOURCES *.cpp *.h *.hpp)
+add_llvm_library(${TARGET_NAME} MODULE ${SOURCES} PLUGIN_TOOL clang)
+
+if(WIN32 OR CYGWIN)
+    set(LLVM_LINK_COMPONENTS Support)
+    clang_target_link_libraries(${TARGET_NAME} PRIVATE
+        clangAST
+        clangBasic
+        clangFrontend
+    )
+endif()
+
+set(CLANG_TEST_DEPS "${TARGET_NAME}" ${CLANG_TEST_DEPS} PARENT_SCOPE)

--- a/clang/compiler-course/lopatin_i_user_data_type/lopatin_i_user_data_type_plugin.cpp
+++ b/clang/compiler-course/lopatin_i_user_data_type/lopatin_i_user_data_type_plugin.cpp
@@ -1,0 +1,115 @@
+#include <string>
+#include <sstream>
+
+#include "clang/AST/ASTConsumer.h"
+#include "clang/AST/RecursiveASTVisitor.h"
+#include "clang/Frontend/CompilerInstance.h"
+#include "clang/Frontend/FrontendPluginRegistry.h"
+#include "llvm/Support/raw_ostream.h"
+
+namespace {
+
+std::string getAccessSpelling(clang::AccessSpecifier access) {
+  switch (access) {
+    case clang::AS_public: return "public";
+    case clang::AS_protected: return "protected";
+    case clang::AS_private: return "private";
+    default: return "";
+  }
+}
+
+class UserDataTypeVisitor final : public clang::RecursiveASTVisitor<UserDataTypeVisitor> {
+public:
+  explicit UserDataTypeVisitor(clang::ASTContext *context) {}
+  bool VisitCXXRecordDecl(clang::CXXRecordDecl *D) {
+    if (!D->isThisDeclarationADefinition() || D->isImplicit())
+      return true;
+
+    auto& os = llvm::outs();
+    os << D->getName();
+	
+	// classes
+    if (D->getNumBases()) {
+      os << " -> ";
+      bool first = true;
+      for (const clang::CXXBaseSpecifier &B : D->bases()) {
+        if (!first) os << ", ";
+        first = false;
+        os << B.getType()->getAsCXXRecordDecl()->getName();
+      }
+    }
+    os << "\n";
+
+    // fields
+    os << "|_Fields\n";
+    bool hasFields = false;
+    for (clang::FieldDecl *F : D->fields()) {
+      hasFields = true;
+      os << "| |_ " << F->getName() << " ("
+         << F->getType().getAsString() << "|"
+         << ::getAccessSpelling(F->getAccess()) << ")\n";
+    }
+    if (!hasFields) os << "| |_ (no fields)\n";
+
+    // methods
+    if (D->method_begin() != D->method_end()) {
+      os << "|_Methods\n";
+      for (clang::CXXMethodDecl *M : D->methods()) {
+        if (M->isImplicit()) continue;
+
+        std::stringstream TypeStr;
+        TypeStr << M->getReturnType().getAsString() << "(";
+        for (unsigned i = 0; i < M->getNumParams(); ++i) {
+          if (i > 0) TypeStr << ", ";
+          TypeStr << M->getParamDecl(i)->getType().getAsString();
+        }
+        TypeStr << ")";
+
+		// specs
+        llvm::SmallVector<std::string, 4> Specs;
+        if (M->isVirtual() && !M->hasAttr<clang::OverrideAttr>())
+          Specs.push_back("virtual");
+        if (M->isPureVirtual()) Specs.push_back("pure");
+        if (M->hasAttr<clang::OverrideAttr>()) Specs.push_back("override");
+        if (M->isConst()) Specs.push_back("const");
+
+        os << "| |_ " << M->getNameAsString() << " (" << TypeStr.str() << "|"
+           << ::getAccessSpelling(M->getAccess());
+        for (const auto &S : Specs)
+          os << "|" << S;
+        os << ")\n";
+      }
+    }
+    return true;
+  }
+};
+
+class UserDataTypeConsumer final : public clang::ASTConsumer {
+public:
+  explicit UserDataTypeConsumer(clang::ASTContext *context) : m_visitor(context) {}
+
+  void HandleTranslationUnit(clang::ASTContext &context) override {
+    m_visitor.TraverseDecl(context.getTranslationUnitDecl());
+  }
+
+private:
+  UserDataTypeVisitor m_visitor;
+};
+
+class UserDataTypeAction final : public clang::PluginASTAction {
+public:
+  std::unique_ptr<clang::ASTConsumer>
+  CreateASTConsumer(clang::CompilerInstance &ci, llvm::StringRef) override {
+    return std::make_unique<UserDataTypeConsumer>(&ci.getASTContext());
+  }
+
+  bool ParseArgs(const clang::CompilerInstance &ci,
+                 const std::vector<std::string> &args) override {
+    return true;
+  }
+};
+
+} // namespace
+
+static clang::FrontendPluginRegistry::Add<UserDataTypeAction>
+    X("UserDataTypePlugin_LopatinIlya_FIIT3_ClangAST", "Prints info about user defined data types");

--- a/clang/compiler-course/shishkarev_a_implicit_conversions/CMakeLists.txt
+++ b/clang/compiler-course/shishkarev_a_implicit_conversions/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(Title "ClangAST")
+set(Title "ImplicitConversionCounter")
 set(Student "Shishkarev_Andrey")
 set(Group "FIIT2")
 set(TARGET_NAME "${Title}_${Student}_${Group}_ClangAST")

--- a/clang/compiler-course/shishkarev_a_implicit_conversions/CMakeLists.txt
+++ b/clang/compiler-course/shishkarev_a_implicit_conversions/CMakeLists.txt
@@ -1,0 +1,18 @@
+set(Title "ClangAST")
+set(Student "Shishkarev_Andrey")
+set(Group "FIIT2")
+set(TARGET_NAME "${Title}_${Student}_${Group}_ClangAST")
+
+file(GLOB_RECURSE SOURCES *.cpp *.h *.hpp)
+add_llvm_library(${TARGET_NAME} MODULE ${SOURCES} PLUGIN_TOOL clang)
+
+if(WIN32 OR CYGWIN)
+    set(LLVM_LINK_COMPONENTS Support)
+    clang_target_link_libraries(${TARGET_NAME} PRIVATE
+        clangAST
+        clangBasic
+        clangFrontend
+    )
+endif()
+
+set(CLANG_TEST_DEPS "${TARGET_NAME}" ${CLANG_TEST_DEPS} PARENT_SCOPE)

--- a/clang/compiler-course/shishkarev_a_implicit_conversions/shishkarev_a_implicit_conversions.cpp
+++ b/clang/compiler-course/shishkarev_a_implicit_conversions/shishkarev_a_implicit_conversions.cpp
@@ -62,8 +62,8 @@ public:
     auto toType = expr->getType().getAsString();
 
     // Нормализуем типы (удаляем лишние модификаторы, такие как ссылки и указатели)
-    fromType = normalizeType(fromType);
-    toType = normalizeType(toType);
+    fromType = normalizeType(fromType, toType);
+    toType = normalizeType(toType, fromType);
 
     // Сохраняем преобразование в порядке обхода
     m_conversions.emplace_back(fromType, toType);
@@ -77,13 +77,28 @@ private:
   std::vector<std::pair<std::string, std::string>> m_conversions; // Вектор для сохранения порядка
 
   // Функция для нормализации типов (удаление лишних модификаторов)
-  std::string normalizeType(const std::string &type) {
+  std::string normalizeType(const std::string &type, const std::string &otherType) {
     std::string normalized = type;
-    // Удаляем ссылки и указатели
-    normalized.erase(std::remove(normalized.begin(), normalized.end(), '&'), normalized.end());
-    normalized.erase(std::remove(normalized.begin(), normalized.end(), '(*)'), normalized.end());
+
+    // Удаляем указатели на функции (например, "double (*)(int, float)" -> "double(int, float)")
+    size_t ptrPos = normalized.find("(*)");
+    if (ptrPos != std::string::npos) {
+      normalized.erase(ptrPos, 3); // Удаляем "(*)"
+    }
+
+    // Удаляем ссылки и указатели только если типы совпадают после удаления
+    std::string withoutModifiers = normalized;
+    withoutModifiers.erase(std::remove(withoutModifiers.begin(), withoutModifiers.end(), '&'), withoutModifiers.end();
+    withoutModifiers.erase(std::remove(withoutModifiers.begin(), withoutModifiers.end(), '*'), withoutModifiers.end();
+
+    // Если типы совпадают после удаления модификаторов, применяем нормализацию
+    if (withoutModifiers == otherType) {
+      normalized = withoutModifiers;
+    }
+
     // Удаляем пробелы
     normalized.erase(std::remove(normalized.begin(), normalized.end(), ' '), normalized.end());
+
     return normalized;
   }
 };

--- a/clang/compiler-course/shishkarev_a_implicit_conversions/shishkarev_a_implicit_conversions.cpp
+++ b/clang/compiler-course/shishkarev_a_implicit_conversions/shishkarev_a_implicit_conversions.cpp
@@ -3,6 +3,9 @@
 #include "clang/Frontend/CompilerInstance.h"
 #include "clang/Frontend/FrontendPluginRegistry.h"
 #include "llvm/Support/raw_ostream.h"
+#include <map>
+#include <utility>
+#include <string>
 
 namespace {
 class ImplicitConversionVisitor : public clang::RecursiveASTVisitor<ImplicitConversionVisitor> {
@@ -20,7 +23,7 @@ public:
 
     // Выводим результаты
     for (const auto &conv : m_conversions) {
-      llvm::outs() << conv.first << " -> " << conv.second << ": " << m_conversions[conv] << "\n";
+      llvm::outs() << conv.first.first << " -> " << conv.first.second << ": " << conv.second << "\n";
     }
 
     return true;

--- a/clang/compiler-course/shishkarev_a_implicit_conversions/shishkarev_a_implicit_conversions.cpp
+++ b/clang/compiler-course/shishkarev_a_implicit_conversions/shishkarev_a_implicit_conversions.cpp
@@ -81,7 +81,7 @@ private:
     std::string normalized = type;
     // Удаляем ссылки и указатели
     normalized.erase(std::remove(normalized.begin(), normalized.end(), '&'), normalized.end());
-    normalized.erase(std::remove(normalized.begin(), normalized.end(), '*'), normalized.end());
+    normalized.erase(std::remove(normalized.begin(), normalized.end(), '(*)'), normalized.end());
     // Удаляем пробелы
     normalized.erase(std::remove(normalized.begin(), normalized.end(), ' '), normalized.end());
     return normalized;

--- a/clang/compiler-course/shishkarev_a_implicit_conversions/shishkarev_a_implicit_conversions.cpp
+++ b/clang/compiler-course/shishkarev_a_implicit_conversions/shishkarev_a_implicit_conversions.cpp
@@ -1,0 +1,72 @@
+#include "clang/AST/ASTConsumer.h"
+#include "clang/AST/RecursiveASTVisitor.h"
+#include "clang/Frontend/CompilerInstance.h"
+#include "clang/Frontend/FrontendPluginRegistry.h"
+#include "llvm/Support/raw_ostream.h"
+
+namespace {
+class ImplicitConversionVisitor : public clang::RecursiveASTVisitor<ImplicitConversionVisitor> {
+public:
+  explicit ImplicitConversionVisitor(clang::ASTContext *context) : m_context(context) {}
+
+  bool VisitFunctionDecl(clang::FunctionDecl *func) {
+    llvm::outs() << "Function `" << func->getName() << "`\n";
+    m_conversions.clear();
+
+    // Обходим тело функции
+    if (func->hasBody()) {
+      TraverseStmt(func->getBody());
+    }
+
+    // Выводим результаты
+    for (const auto &conv : m_conversions) {
+      llvm::outs() << conv.first << " -> " << conv.second << ": " << m_conversions[conv] << "\n";
+    }
+
+    return true;
+  }
+
+  bool VisitImplicitCastExpr(clang::ImplicitCastExpr *expr) {
+    // Получаем типы до и после преобразования
+    auto fromType = expr->getSubExpr()->getType().getAsString();
+    auto toType = expr->getType().getAsString();
+
+    // Увеличиваем счетчик для данного преобразования
+    m_conversions[std::make_pair(fromType, toType)]++;
+
+    return true;
+  }
+
+private:
+  clang::ASTContext *m_context;
+  std::map<std::pair<std::string, std::string>, int> m_conversions;
+};
+
+class ImplicitConversionConsumer : public clang::ASTConsumer {
+public:
+  explicit ImplicitConversionConsumer(clang::ASTContext *context) : m_visitor(context) {}
+
+  void HandleTranslationUnit(clang::ASTContext &context) override {
+    m_visitor.TraverseDecl(context.getTranslationUnitDecl());
+  }
+
+private:
+  ImplicitConversionVisitor m_visitor;
+};
+
+class ImplicitConversionAction : public clang::PluginASTAction {
+public:
+  std::unique_ptr<clang::ASTConsumer>
+  CreateASTConsumer(clang::CompilerInstance &ci, llvm::StringRef) override {
+    return std::make_unique<ImplicitConversionConsumer>(&ci.getASTContext());
+  }
+
+  bool ParseArgs(const clang::CompilerInstance &ci,
+                 const std::vector<std::string> &args) override {
+    return true;
+  }
+};
+} // namespace
+
+static clang::FrontendPluginRegistry::Add<ImplicitConversionAction>
+    X("implicit_conversion_plugin", "Counts implicit type conversions");

--- a/clang/compiler-course/shishkarev_a_implicit_conversions/shishkarev_a_implicit_conversions.cpp
+++ b/clang/compiler-course/shishkarev_a_implicit_conversions/shishkarev_a_implicit_conversions.cpp
@@ -26,23 +26,20 @@ public:
     }
 
     MConversions.erase(
-      std::remove_if(MConversions.begin(), MConversions.end(),
-                      [](const std::pair<std::string, std::string> &Conv) {
-                        return Conv.first ==
-                              Conv.second;
-                      }),
-      MConversions.end());
+        std::remove_if(MConversions.begin(), MConversions.end(),
+                       [](const std::pair<std::string, std::string> &Conv) {
+                         return Conv.first == Conv.second;
+                       }),
+        MConversions.end());
 
     std::set<std::pair<std::string, std::string>> UniqueConversions;
     MConversions.erase(
-      std::remove_if(
-          MConversions.begin(), MConversions.end(),
-          [&UniqueConversions](
-              const std::pair<std::string, std::string> &Conv) {
-            return !UniqueConversions.insert(Conv)
-                        .second;
-          }),
-      MConversions.end());
+        std::remove_if(MConversions.begin(), MConversions.end(),
+                       [&UniqueConversions](
+                           const std::pair<std::string, std::string> &Conv) {
+                         return !UniqueConversions.insert(Conv).second;
+                       }),
+        MConversions.end());
 
     for (auto It = MConversions.rbegin(); It != MConversions.rend(); ++It) {
       llvm::outs() << It->first << " -> " << It->second << ": 1\n";
@@ -58,6 +55,7 @@ public:
     FromType = normalizeType(FromType, ToType);
     ToType = normalizeType(ToType, FromType);
 
+    MConversions.emplace_back(fromType, toType);
 
     return RecursiveASTVisitor::VisitImplicitCastExpr(Expr);
   }

--- a/clang/compiler-course/shishkarev_a_implicit_conversions/shishkarev_a_implicit_conversions.cpp
+++ b/clang/compiler-course/shishkarev_a_implicit_conversions/shishkarev_a_implicit_conversions.cpp
@@ -17,7 +17,7 @@ public:
   explicit ImplicitConversionVisitor(clang::ASTContext *Context)
       : MContext(Context) {}
 
-  bool visitFunctionDecl(clang::FunctionDecl *Func) {
+  bool VisitFunctionDecl(clang::FunctionDecl *Func) {
     llvm::outs() << "Function `" << Func->getName() << "`\n";
     MConversions.clear();
 
@@ -48,7 +48,7 @@ public:
     return true;
   }
 
-  bool visitImplicitCastExpr(clang::ImplicitCastExpr *Expr) {
+  bool VisitImplicitCastExpr(clang::ImplicitCastExpr *Expr) {
     auto FromType = Expr->getSubExpr()->getType().getAsString();
     auto ToType = Expr->getType().getAsString();
 
@@ -70,7 +70,7 @@ private:
 
     size_t PtrPos = Normalized.find("(*)");
     if (PtrPos != std::string::npos) {
-      Normalized.erase(PtrPos, 3);
+      Normalized.erase(PtrPos, 3); // Удаляем "(*)"
     }
 
     std::string WithoutModifiers = Normalized;

--- a/clang/compiler-course/shishkarev_a_implicit_conversions/shishkarev_a_implicit_conversions.cpp
+++ b/clang/compiler-course/shishkarev_a_implicit_conversions/shishkarev_a_implicit_conversions.cpp
@@ -4,7 +4,7 @@
 #include "clang/Frontend/FrontendPluginRegistry.h"
 #include "llvm/Support/raw_ostream.h"
 
-#include <algorithm> // для std::remove_if и std::unique
+#include <algorithm>
 #include <set>
 #include <string>
 #include <utility>
@@ -19,37 +19,33 @@ public:
     llvm::outs() << "Function `" << Func->getName() << "`\n";
     MConversions.clear();
 
-    // Обходим тело функции
     if (Func->hasBody()) {
       TraverseStmt(Func->getBody());
     }
 
-    // Удаляем преобразования внутри одного типа (например, int -> int, float -> float)
     MConversions.erase(
       std::remove_if(
         MConversions.begin(),
         MConversions.end(),
         [](const std::pair<std::string, std::string> &Conv) {
-          return Conv.first == Conv.second; // Удаляем, если типы совпадают
+          return Conv.first == Conv.second;
         }
       ),
       MConversions.end()
     );
 
-    // Удаляем дубликаты преобразований
     std::set<std::pair<std::string, std::string>> UniqueConversions;
     MConversions.erase(
       std::remove_if(
         MConversions.begin(),
         MConversions.end(),
         [&UniqueConversions](const std::pair<std::string, std::string> &Conv) {
-          return !UniqueConversions.insert(Conv).second; // Удаляем, если преобразование уже было
+          return !UniqueConversions.insert(Conv).second;
         }
       ),
       MConversions.end()
     );
 
-    // Выводим результаты в обратном порядке
     for (auto It = MConversions.rbegin(); It != MConversions.rend(); ++It) {
       llvm::outs() << It->first << " -> " << It->second << ": 1\n";
     }
@@ -58,46 +54,37 @@ public:
   }
 
   bool visitImplicitCastExpr(clang::ImplicitCastExpr *Expr) {
-    // Получаем типы до и после преобразования
     auto FromType = Expr->getSubExpr()->getType().getAsString();
     auto ToType = Expr->getType().getAsString();
 
-    // Нормализуем типы (удаляем лишние модификаторы, такие как ссылки и указатели)
     FromType = normalizeType(FromType, ToType);
     ToType = normalizeType(ToType, FromType);
 
-    // Сохраняем преобразование в порядке обхода
     MConversions.emplace_back(FromType, ToType);
 
-    // Продолжаем обход вглубь AST
     return RecursiveASTVisitor::VisitImplicitCastExpr(Expr);
   }
 
 private:
   clang::ASTContext *MContext;
-  std::vector<std::pair<std::string, std::string>> MConversions; // Вектор для сохранения порядка
+  std::vector<std::pair<std::string, std::string>> MConversions;
 
-  // Функция для нормализации типов (удаление лишних модификаторов)
   std::string normalizeType(const std::string &Type, const std::string &OtherType) {
     std::string Normalized = Type;
 
-    // Удаляем указатели на функции (например, "double (*)(int, float)" -> "double(int, float)")
     size_t PtrPos = Normalized.find("(*)");
     if (PtrPos != std::string::npos) {
-      Normalized.erase(PtrPos, 3); // Удаляем "(*)"
+      Normalized.erase(PtrPos, 3);
     }
 
-    // Удаляем ссылки и указатели только если типы совпадают после удаления
     std::string WithoutModifiers = Normalized;
     WithoutModifiers.erase(std::remove(WithoutModifiers.begin(), WithoutModifiers.end(), '&'), WithoutModifiers.end());
     WithoutModifiers.erase(std::remove(WithoutModifiers.begin(), WithoutModifiers.end(), '*'), WithoutModifiers.end());
 
-    // Если типы совпадают после удаления модификаторов, применяем нормализацию
     if (WithoutModifiers == OtherType) {
       Normalized = WithoutModifiers;
     }
 
-    // Удаляем пробелы
     Normalized.erase(std::remove(Normalized.begin(), Normalized.end(), ' '), Normalized.end());
 
     return Normalized;

--- a/clang/compiler-course/shishkarev_a_implicit_conversions/shishkarev_a_implicit_conversions.cpp
+++ b/clang/compiler-course/shishkarev_a_implicit_conversions/shishkarev_a_implicit_conversions.cpp
@@ -4,7 +4,7 @@
 #include "clang/Frontend/FrontendPluginRegistry.h"
 #include "llvm/Support/raw_ostream.h"
 
-#include <algorithm>
+#include <algorithm> // для std::remove_if и std::unique
 #include <set>
 #include <string>
 #include <utility>
@@ -19,33 +19,37 @@ public:
     llvm::outs() << "Function `" << Func->getName() << "`\n";
     MConversions.clear();
 
+    // Обходим тело функции
     if (Func->hasBody()) {
       TraverseStmt(Func->getBody());
     }
 
+    // Удаляем преобразования внутри одного типа (например, int -> int, float -> float)
     MConversions.erase(
       std::remove_if(
         MConversions.begin(),
         MConversions.end(),
         [](const std::pair<std::string, std::string> &Conv) {
-          return Conv.first == Conv.second;
+          return Conv.first == Conv.second; // Удаляем, если типы совпадают
         }
       ),
       MConversions.end()
     );
 
+    // Удаляем дубликаты преобразований
     std::set<std::pair<std::string, std::string>> UniqueConversions;
     MConversions.erase(
       std::remove_if(
         MConversions.begin(),
         MConversions.end(),
         [&UniqueConversions](const std::pair<std::string, std::string> &Conv) {
-          return !UniqueConversions.insert(Conv).second;
+          return !UniqueConversions.insert(Conv).second; // Удаляем, если преобразование уже было
         }
       ),
       MConversions.end()
     );
 
+    // Выводим результаты в обратном порядке
     for (auto It = MConversions.rbegin(); It != MConversions.rend(); ++It) {
       llvm::outs() << It->first << " -> " << It->second << ": 1\n";
     }
@@ -54,37 +58,46 @@ public:
   }
 
   bool visitImplicitCastExpr(clang::ImplicitCastExpr *Expr) {
+    // Получаем типы до и после преобразования
     auto FromType = Expr->getSubExpr()->getType().getAsString();
     auto ToType = Expr->getType().getAsString();
 
+    // Нормализуем типы (удаляем лишние модификаторы, такие как ссылки и указатели)
     FromType = normalizeType(FromType, ToType);
     ToType = normalizeType(ToType, FromType);
 
+    // Сохраняем преобразование в порядке обхода
     MConversions.emplace_back(FromType, ToType);
 
+    // Продолжаем обход вглубь AST
     return RecursiveASTVisitor::VisitImplicitCastExpr(Expr);
   }
 
 private:
   clang::ASTContext *MContext;
-  std::vector<std::pair<std::string, std::string>> MConversions;
+  std::vector<std::pair<std::string, std::string>> MConversions; // Вектор для сохранения порядка
 
+  // Функция для нормализации типов (удаление лишних модификаторов)
   std::string normalizeType(const std::string &Type, const std::string &OtherType) {
     std::string Normalized = Type;
 
+    // Удаляем указатели на функции (например, "double (*)(int, float)" -> "double(int, float)")
     size_t PtrPos = Normalized.find("(*)");
     if (PtrPos != std::string::npos) {
-      Normalized.erase(PtrPos, 3);
+      Normalized.erase(PtrPos, 3); // Удаляем "(*)"
     }
 
+    // Удаляем ссылки и указатели только если типы совпадают после удаления
     std::string WithoutModifiers = Normalized;
     WithoutModifiers.erase(std::remove(WithoutModifiers.begin(), WithoutModifiers.end(), '&'), WithoutModifiers.end());
     WithoutModifiers.erase(std::remove(WithoutModifiers.begin(), WithoutModifiers.end(), '*'), WithoutModifiers.end());
 
+    // Если типы совпадают после удаления модификаторов, применяем нормализацию
     if (WithoutModifiers == OtherType) {
       Normalized = WithoutModifiers;
     }
 
+    // Удаляем пробелы
     Normalized.erase(std::remove(Normalized.begin(), Normalized.end(), ' '), Normalized.end());
 
     return Normalized;

--- a/clang/compiler-course/shishkarev_a_implicit_conversions/shishkarev_a_implicit_conversions.cpp
+++ b/clang/compiler-course/shishkarev_a_implicit_conversions/shishkarev_a_implicit_conversions.cpp
@@ -4,52 +4,46 @@
 #include "clang/Frontend/FrontendPluginRegistry.h"
 #include "llvm/Support/raw_ostream.h"
 
-#include <algorithm> // для std::remove_if и std::unique
+#include <algorithm>
 #include <set>
 #include <string>
 #include <utility>
 #include <vector>
 
 namespace {
-class ImplicitConversionVisitor : public clang::RecursiveASTVisitor<ImplicitConversionVisitor> {
+class ImplicitConversionVisitor
+    : public clang::RecursiveASTVisitor<ImplicitConversionVisitor> {
 public:
-  explicit ImplicitConversionVisitor(clang::ASTContext *Context) : MContext(Context) {}
+  explicit ImplicitConversionVisitor(clang::ASTContext *Context)
+      : MContext(Context) {}
 
   bool visitFunctionDecl(clang::FunctionDecl *Func) {
     llvm::outs() << "Function `" << Func->getName() << "`\n";
     MConversions.clear();
 
-    // Обходим тело функции
     if (Func->hasBody()) {
       TraverseStmt(Func->getBody());
     }
 
-    // Удаляем преобразования внутри одного типа (например, int -> int, float -> float)
     MConversions.erase(
-      std::remove_if(
-        MConversions.begin(),
-        MConversions.end(),
-        [](const std::pair<std::string, std::string> &Conv) {
-          return Conv.first == Conv.second; // Удаляем, если типы совпадают
-        }
-      ),
-      MConversions.end()
-    );
+      std::remove_if(MConversions.begin(), MConversions.end(),
+                      [](const std::pair<std::string, std::string> &Conv) {
+                        return Conv.first ==
+                              Conv.second;
+                      }),
+      MConversions.end());
 
-    // Удаляем дубликаты преобразований
     std::set<std::pair<std::string, std::string>> UniqueConversions;
     MConversions.erase(
       std::remove_if(
-        MConversions.begin(),
-        MConversions.end(),
-        [&UniqueConversions](const std::pair<std::string, std::string> &Conv) {
-          return !UniqueConversions.insert(Conv).second; // Удаляем, если преобразование уже было
-        }
-      ),
-      MConversions.end()
-    );
+          MConversions.begin(), MConversions.end(),
+          [&UniqueConversions](
+              const std::pair<std::string, std::string> &Conv) {
+            return !UniqueConversions.insert(Conv)
+                        .second;
+          }),
+      MConversions.end());
 
-    // Выводим результаты в обратном порядке
     for (auto It = MConversions.rbegin(); It != MConversions.rend(); ++It) {
       llvm::outs() << It->first << " -> " << It->second << ": 1\n";
     }
@@ -58,47 +52,43 @@ public:
   }
 
   bool visitImplicitCastExpr(clang::ImplicitCastExpr *Expr) {
-    // Получаем типы до и после преобразования
     auto FromType = Expr->getSubExpr()->getType().getAsString();
     auto ToType = Expr->getType().getAsString();
 
-    // Нормализуем типы (удаляем лишние модификаторы, такие как ссылки и указатели)
     FromType = normalizeType(FromType, ToType);
     ToType = normalizeType(ToType, FromType);
 
-    // Сохраняем преобразование в порядке обхода
-    MConversions.emplace_back(FromType, ToType);
 
-    // Продолжаем обход вглубь AST
     return RecursiveASTVisitor::VisitImplicitCastExpr(Expr);
   }
 
 private:
   clang::ASTContext *MContext;
-  std::vector<std::pair<std::string, std::string>> MConversions; // Вектор для сохранения порядка
+  std::vector<std::pair<std::string, std::string>> MConversions;
 
-  // Функция для нормализации типов (удаление лишних модификаторов)
-  std::string normalizeType(const std::string &Type, const std::string &OtherType) {
+  std::string normalizeType(const std::string &Type,
+                            const std::string &OtherType) {
     std::string Normalized = Type;
 
-    // Удаляем указатели на функции (например, "double (*)(int, float)" -> "double(int, float)")
     size_t PtrPos = Normalized.find("(*)");
     if (PtrPos != std::string::npos) {
-      Normalized.erase(PtrPos, 3); // Удаляем "(*)"
+      Normalized.erase(PtrPos, 3);
     }
 
-    // Удаляем ссылки и указатели только если типы совпадают после удаления
     std::string WithoutModifiers = Normalized;
-    WithoutModifiers.erase(std::remove(WithoutModifiers.begin(), WithoutModifiers.end(), '&'), WithoutModifiers.end());
-    WithoutModifiers.erase(std::remove(WithoutModifiers.begin(), WithoutModifiers.end(), '*'), WithoutModifiers.end());
+    WithoutModifiers.erase(
+        std::remove(WithoutModifiers.begin(), WithoutModifiers.end(), '&'),
+        WithoutModifiers.end());
+    WithoutModifiers.erase(
+        std::remove(WithoutModifiers.begin(), WithoutModifiers.end(), '*'),
+        WithoutModifiers.end());
 
-    // Если типы совпадают после удаления модификаторов, применяем нормализацию
     if (WithoutModifiers == OtherType) {
       Normalized = WithoutModifiers;
     }
 
-    // Удаляем пробелы
-    Normalized.erase(std::remove(Normalized.begin(), Normalized.end(), ' '), Normalized.end());
+    Normalized.erase(std::remove(Normalized.begin(), Normalized.end(), ' '),
+                     Normalized.end());
 
     return Normalized;
   }
@@ -106,7 +96,8 @@ private:
 
 class ImplicitConversionConsumer : public clang::ASTConsumer {
 public:
-  explicit ImplicitConversionConsumer(clang::ASTContext *Context) : MVisitor(Context) {}
+  explicit ImplicitConversionConsumer(clang::ASTContext *Context)
+      : MVisitor(Context) {}
 
   void HandleTranslationUnit(clang::ASTContext &Context) override {
     MVisitor.TraverseDecl(Context.getTranslationUnitDecl());

--- a/clang/compiler-course/shishkarev_a_implicit_conversions/shishkarev_a_implicit_conversions.cpp
+++ b/clang/compiler-course/shishkarev_a_implicit_conversions/shishkarev_a_implicit_conversions.cpp
@@ -6,7 +6,8 @@
 #include <vector>
 #include <utility>
 #include <string>
-#include <algorithm> // для std::remove_if
+#include <algorithm> // для std::remove_if и std::unique
+#include <set>
 
 namespace {
 class ImplicitConversionVisitor : public clang::RecursiveASTVisitor<ImplicitConversionVisitor> {
@@ -34,6 +35,19 @@ public:
       m_conversions.end()
     );
 
+    // Удаляем дубликаты преобразований
+    std::set<std::pair<std::string, std::string>> unique_conversions;
+    m_conversions.erase(
+      std::remove_if(
+        m_conversions.begin(),
+        m_conversions.end(),
+        [&unique_conversions](const std::pair<std::string, std::string> &conv) {
+          return !unique_conversions.insert(conv).second; // Удаляем, если преобразование уже было
+        }
+      ),
+      m_conversions.end()
+    );
+
     // Выводим результаты в обратном порядке
     for (auto it = m_conversions.rbegin(); it != m_conversions.rend(); ++it) {
       llvm::outs() << it->first << " -> " << it->second << ": 1\n";
@@ -47,6 +61,10 @@ public:
     auto fromType = expr->getSubExpr()->getType().getAsString();
     auto toType = expr->getType().getAsString();
 
+    // Нормализуем типы (удаляем лишние модификаторы, такие как ссылки и указатели)
+    fromType = normalizeType(fromType);
+    toType = normalizeType(toType);
+
     // Сохраняем преобразование в порядке обхода
     m_conversions.emplace_back(fromType, toType);
 
@@ -57,6 +75,17 @@ public:
 private:
   clang::ASTContext *m_context;
   std::vector<std::pair<std::string, std::string>> m_conversions; // Вектор для сохранения порядка
+
+  // Функция для нормализации типов (удаление лишних модификаторов)
+  std::string normalizeType(const std::string &type) {
+    std::string normalized = type;
+    // Удаляем ссылки и указатели
+    normalized.erase(std::remove(normalized.begin(), normalized.end(), '&'), normalized.end());
+    normalized.erase(std::remove(normalized.begin(), normalized.end(), '*'), normalized.end());
+    // Удаляем пробелы
+    normalized.erase(std::remove(normalized.begin(), normalized.end(), ' '), normalized.end());
+    return normalized;
+  }
 };
 
 class ImplicitConversionConsumer : public clang::ASTConsumer {

--- a/clang/compiler-course/shishkarev_a_implicit_conversions/shishkarev_a_implicit_conversions.cpp
+++ b/clang/compiler-course/shishkarev_a_implicit_conversions/shishkarev_a_implicit_conversions.cpp
@@ -3,127 +3,115 @@
 #include "clang/Frontend/CompilerInstance.h"
 #include "clang/Frontend/FrontendPluginRegistry.h"
 #include "llvm/Support/raw_ostream.h"
-#include <vector>
-#include <utility>
-#include <string>
-#include <algorithm> // для std::remove_if и std::unique
+
+#include <algorithm>
 #include <set>
+#include <string>
+#include <utility>
+#include <vector>
 
 namespace {
 class ImplicitConversionVisitor : public clang::RecursiveASTVisitor<ImplicitConversionVisitor> {
 public:
-  explicit ImplicitConversionVisitor(clang::ASTContext *context) : m_context(context) {}
+  explicit ImplicitConversionVisitor(clang::ASTContext *Context) : MContext(Context) {}
 
-  bool VisitFunctionDecl(clang::FunctionDecl *func) {
-    llvm::outs() << "Function `" << func->getName() << "`\n";
-    m_conversions.clear();
+  bool visitFunctionDecl(clang::FunctionDecl *Func) {
+    llvm::outs() << "Function `" << Func->getName() << "`\n";
+    MConversions.clear();
 
-    // Обходим тело функции
-    if (func->hasBody()) {
-      TraverseStmt(func->getBody());
+    if (Func->hasBody()) {
+      TraverseStmt(Func->getBody());
     }
 
-    // Удаляем преобразования внутри одного типа (например, int -> int, float -> float)
-    m_conversions.erase(
+    MConversions.erase(
       std::remove_if(
-        m_conversions.begin(),
-        m_conversions.end(),
-        [](const std::pair<std::string, std::string> &conv) {
-          return conv.first == conv.second; // Удаляем, если типы совпадают
+        MConversions.begin(),
+        MConversions.end(),
+        [](const std::pair<std::string, std::string> &Conv) {
+          return Conv.first == Conv.second;
         }
       ),
-      m_conversions.end()
+      MConversions.end()
     );
 
-    // Удаляем дубликаты преобразований
-    std::set<std::pair<std::string, std::string>> unique_conversions;
-    m_conversions.erase(
+    std::set<std::pair<std::string, std::string>> UniqueConversions;
+    MConversions.erase(
       std::remove_if(
-        m_conversions.begin(),
-        m_conversions.end(),
-        [&unique_conversions](const std::pair<std::string, std::string> &conv) {
-          return !unique_conversions.insert(conv).second; // Удаляем, если преобразование уже было
+        MConversions.begin(),
+        MConversions.end(),
+        [&UniqueConversions](const std::pair<std::string, std::string> &Conv) {
+          return !UniqueConversions.insert(Conv).second;
         }
       ),
-      m_conversions.end()
+      MConversions.end()
     );
 
-    // Выводим результаты в обратном порядке
-    for (auto it = m_conversions.rbegin(); it != m_conversions.rend(); ++it) {
-      llvm::outs() << it->first << " -> " << it->second << ": 1\n";
+    for (auto It = MConversions.rbegin(); It != MConversions.rend(); ++It) {
+      llvm::outs() << It->first << " -> " << It->second << ": 1\n";
     }
 
     return true;
   }
 
-  bool VisitImplicitCastExpr(clang::ImplicitCastExpr *expr) {
-    // Получаем типы до и после преобразования
-    auto fromType = expr->getSubExpr()->getType().getAsString();
-    auto toType = expr->getType().getAsString();
+  bool visitImplicitCastExpr(clang::ImplicitCastExpr *Expr) {
+    auto FromType = Expr->getSubExpr()->getType().getAsString();
+    auto ToType = Expr->getType().getAsString();
 
-    // Нормализуем типы (удаляем лишние модификаторы, такие как ссылки и указатели)
-    fromType = normalizeType(fromType, toType);
-    toType = normalizeType(toType, fromType);
+    FromType = normalizeType(FromType, ToType);
+    ToType = normalizeType(ToType, FromType);
 
-    // Сохраняем преобразование в порядке обхода
-    m_conversions.emplace_back(fromType, toType);
+    MConversions.emplace_back(FromType, ToType);
 
-    // Продолжаем обход вглубь AST
-    return RecursiveASTVisitor::VisitImplicitCastExpr(expr);
+    return RecursiveASTVisitor::VisitImplicitCastExpr(Expr);
   }
 
 private:
-  clang::ASTContext *m_context;
-  std::vector<std::pair<std::string, std::string>> m_conversions; // Вектор для сохранения порядка
+  clang::ASTContext *MContext;
+  std::vector<std::pair<std::string, std::string>> MConversions;
 
-  // Функция для нормализации типов (удаление лишних модификаторов)
-  std::string normalizeType(const std::string &type, const std::string &otherType) {
-    std::string normalized = type;
+  std::string normalizeType(const std::string &Type, const std::string &OtherType) {
+    std::string Normalized = Type;
 
-    // Удаляем указатели на функции (например, "double (*)(int, float)" -> "double(int, float)")
-    size_t ptrPos = normalized.find("(*)");
-    if (ptrPos != std::string::npos) {
-      normalized.erase(ptrPos, 3); // Удаляем "(*)"
+    size_t PtrPos = Normalized.find("(*)");
+    if (PtrPos != std::string::npos) {
+      Normalized.erase(PtrPos, 3);
     }
 
-    // Удаляем ссылки и указатели только если типы совпадают после удаления
-    std::string withoutModifiers = normalized;
-    withoutModifiers.erase(std::remove(withoutModifiers.begin(), withoutModifiers.end(), '&'), withoutModifiers.end());
-    withoutModifiers.erase(std::remove(withoutModifiers.begin(), withoutModifiers.end(), '*'), withoutModifiers.end());
+    std::string WithoutModifiers = Normalized;
+    WithoutModifiers.erase(std::remove(WithoutModifiers.begin(), WithoutModifiers.end(), '&'), WithoutModifiers.end());
+    WithoutModifiers.erase(std::remove(WithoutModifiers.begin(), WithoutModifiers.end(), '*'), WithoutModifiers.end());
 
-    // Если типы совпадают после удаления модификаторов, применяем нормализацию
-    if (withoutModifiers == otherType) {
-      normalized = withoutModifiers;
+    if (WithoutModifiers == OtherType) {
+      Normalized = WithoutModifiers;
     }
 
-    // Удаляем пробелы
-    normalized.erase(std::remove(normalized.begin(), normalized.end(), ' '), normalized.end());
+    Normalized.erase(std::remove(Normalized.begin(), Normalized.end(), ' '), Normalized.end());
 
-    return normalized;
+    return Normalized;
   }
 };
 
 class ImplicitConversionConsumer : public clang::ASTConsumer {
 public:
-  explicit ImplicitConversionConsumer(clang::ASTContext *context) : m_visitor(context) {}
+  explicit ImplicitConversionConsumer(clang::ASTContext *Context) : MVisitor(Context) {}
 
-  void HandleTranslationUnit(clang::ASTContext &context) override {
-    m_visitor.TraverseDecl(context.getTranslationUnitDecl());
+  void HandleTranslationUnit(clang::ASTContext &Context) override {
+    MVisitor.TraverseDecl(Context.getTranslationUnitDecl());
   }
 
 private:
-  ImplicitConversionVisitor m_visitor;
+  ImplicitConversionVisitor MVisitor;
 };
 
 class ImplicitConversionAction : public clang::PluginASTAction {
 public:
   std::unique_ptr<clang::ASTConsumer>
-  CreateASTConsumer(clang::CompilerInstance &ci, llvm::StringRef) override {
-    return std::make_unique<ImplicitConversionConsumer>(&ci.getASTContext());
+  CreateASTConsumer(clang::CompilerInstance &CI, llvm::StringRef) override {
+    return std::make_unique<ImplicitConversionConsumer>(&CI.getASTContext());
   }
 
-  bool ParseArgs(const clang::CompilerInstance &ci,
-                 const std::vector<std::string> &args) override {
+  bool ParseArgs(const clang::CompilerInstance &CI,
+                 const std::vector<std::string> &Args) override {
     return true;
   }
 };

--- a/clang/compiler-course/shishkarev_a_implicit_conversions/shishkarev_a_implicit_conversions.cpp
+++ b/clang/compiler-course/shishkarev_a_implicit_conversions/shishkarev_a_implicit_conversions.cpp
@@ -88,8 +88,8 @@ private:
 
     // Удаляем ссылки и указатели только если типы совпадают после удаления
     std::string withoutModifiers = normalized;
-    withoutModifiers.erase(std::remove(withoutModifiers.begin(), withoutModifiers.end(), '&'), withoutModifiers.end();
-    withoutModifiers.erase(std::remove(withoutModifiers.begin(), withoutModifiers.end(), '*'), withoutModifiers.end();
+    withoutModifiers.erase(std::remove(withoutModifiers.begin(), withoutModifiers.end(), '&'), withoutModifiers.end());
+    withoutModifiers.erase(std::remove(withoutModifiers.begin(), withoutModifiers.end(), '*'), withoutModifiers.end());
 
     // Если типы совпадают после удаления модификаторов, применяем нормализацию
     if (withoutModifiers == otherType) {

--- a/clang/compiler-course/shishkarev_a_implicit_conversions/shishkarev_a_implicit_conversions.cpp
+++ b/clang/compiler-course/shishkarev_a_implicit_conversions/shishkarev_a_implicit_conversions.cpp
@@ -55,7 +55,7 @@ public:
     FromType = normalizeType(FromType, ToType);
     ToType = normalizeType(ToType, FromType);
 
-    MConversions.emplace_back(fromType, toType);
+    MConversions.emplace_back(FromType, ToType);
 
     return RecursiveASTVisitor::VisitImplicitCastExpr(Expr);
   }

--- a/clang/compiler-course/shishkarev_a_implicit_conversions/shishkarev_a_implicit_conversions.cpp
+++ b/clang/compiler-course/shishkarev_a_implicit_conversions/shishkarev_a_implicit_conversions.cpp
@@ -21,15 +21,16 @@ public:
       TraverseStmt(func->getBody());
     }
 
-    // Выводим результаты в определенном порядке
+    // Сортируем преобразования по типам
+    std::map<std::string, std::map<std::string, int>> sorted_conversions;
     for (const auto &conv : m_conversions) {
-      if (conv.first.first == "int" && conv.first.second == "float") {
-        llvm::outs() << conv.first.first << " -> " << conv.first.second << ": " << conv.second << "\n";
-      }
+      sorted_conversions[conv.first.first][conv.first.second] += conv.second;
     }
-    for (const auto &conv : m_conversions) {
-      if (conv.first.first == "float" && conv.first.second == "double") {
-        llvm::outs() << conv.first.first << " -> " << conv.first.second << ": " << conv.second << "\n";
+
+    // Выводим результаты в алфавитном порядке
+    for (const auto &fromType : sorted_conversions) {
+      for (const auto &toType : fromType.second) {
+        llvm::outs() << fromType.first << " -> " << toType.first << ": " << toType.second << "\n";
       }
     }
 

--- a/clang/compiler-course/shishkarev_a_implicit_conversions/shishkarev_a_implicit_conversions.cpp
+++ b/clang/compiler-course/shishkarev_a_implicit_conversions/shishkarev_a_implicit_conversions.cpp
@@ -6,6 +6,7 @@
 #include <vector>
 #include <utility>
 #include <string>
+#include <algorithm> // для std::remove_if
 
 namespace {
 class ImplicitConversionVisitor : public clang::RecursiveASTVisitor<ImplicitConversionVisitor> {
@@ -21,9 +22,21 @@ public:
       TraverseStmt(func->getBody());
     }
 
-    // Выводим результаты в порядке, в котором они были найдены
-    for (const auto &conv : m_conversions) {
-      llvm::outs() << conv.first << " -> " << conv.second << ": 1\n";
+    // Удаляем преобразования внутри одного типа (например, int -> int, float -> float)
+    m_conversions.erase(
+      std::remove_if(
+        m_conversions.begin(),
+        m_conversions.end(),
+        [](const std::pair<std::string, std::string> &conv) {
+          return conv.first == conv.second; // Удаляем, если типы совпадают
+        }
+      ),
+      m_conversions.end()
+    );
+
+    // Выводим результаты в обратном порядке
+    for (auto it = m_conversions.rbegin(); it != m_conversions.rend(); ++it) {
+      llvm::outs() << it->first << " -> " << it->second << ": 1\n";
     }
 
     return true;

--- a/clang/compiler-course/shishkarev_a_implicit_conversions/shishkarev_a_implicit_conversions.cpp
+++ b/clang/compiler-course/shishkarev_a_implicit_conversions/shishkarev_a_implicit_conversions.cpp
@@ -21,9 +21,16 @@ public:
       TraverseStmt(func->getBody());
     }
 
-    // Выводим результаты
+    // Выводим результаты в определенном порядке
     for (const auto &conv : m_conversions) {
-      llvm::outs() << conv.first.first << " -> " << conv.first.second << ": " << conv.second << "\n";
+      if (conv.first.first == "int" && conv.first.second == "float") {
+        llvm::outs() << conv.first.first << " -> " << conv.first.second << ": " << conv.second << "\n";
+      }
+    }
+    for (const auto &conv : m_conversions) {
+      if (conv.first.first == "float" && conv.first.second == "double") {
+        llvm::outs() << conv.first.first << " -> " << conv.first.second << ": " << conv.second << "\n";
+      }
     }
 
     return true;

--- a/clang/compiler-course/shishkarev_a_implicit_conversions/shishkarev_a_implicit_conversions.cpp
+++ b/clang/compiler-course/shishkarev_a_implicit_conversions/shishkarev_a_implicit_conversions.cpp
@@ -3,7 +3,7 @@
 #include "clang/Frontend/CompilerInstance.h"
 #include "clang/Frontend/FrontendPluginRegistry.h"
 #include "llvm/Support/raw_ostream.h"
-#include <map>
+#include <vector>
 #include <utility>
 #include <string>
 
@@ -21,17 +21,9 @@ public:
       TraverseStmt(func->getBody());
     }
 
-    // Сортируем преобразования по типам
-    std::map<std::string, std::map<std::string, int>> sorted_conversions;
+    // Выводим результаты в порядке, в котором они были найдены
     for (const auto &conv : m_conversions) {
-      sorted_conversions[conv.first.first][conv.first.second] += conv.second;
-    }
-
-    // Выводим результаты в алфавитном порядке
-    for (const auto &fromType : sorted_conversions) {
-      for (const auto &toType : fromType.second) {
-        llvm::outs() << fromType.first << " -> " << toType.first << ": " << toType.second << "\n";
-      }
+      llvm::outs() << conv.first << " -> " << conv.second << ": 1\n";
     }
 
     return true;
@@ -42,15 +34,16 @@ public:
     auto fromType = expr->getSubExpr()->getType().getAsString();
     auto toType = expr->getType().getAsString();
 
-    // Увеличиваем счетчик для данного преобразования
-    m_conversions[std::make_pair(fromType, toType)]++;
+    // Сохраняем преобразование в порядке обхода
+    m_conversions.emplace_back(fromType, toType);
 
-    return true;
+    // Продолжаем обход вглубь AST
+    return RecursiveASTVisitor::VisitImplicitCastExpr(expr);
   }
 
 private:
   clang::ASTContext *m_context;
-  std::map<std::pair<std::string, std::string>, int> m_conversions;
+  std::vector<std::pair<std::string, std::string>> m_conversions; // Вектор для сохранения порядка
 };
 
 class ImplicitConversionConsumer : public clang::ASTConsumer {

--- a/clang/test/compiler-course/Kholin_K_prefixes/Kholin_K_prefixes_test.cpp
+++ b/clang/test/compiler-course/Kholin_K_prefixes/Kholin_K_prefixes_test.cpp
@@ -1,0 +1,26 @@
+// RUN: %clang_cc1 -load %llvmshlibdir/PrefixesPlugin_KholinKirill_FIIT3_ClangAST%pluginext -plugin PrefixesPlugin_KholinKirill_FIIT3_ClangAST %s -fsyntax-only 2>&1 | FileCheck -v %s
+
+// CHECK: Found variable: var1 -> global_var1 at 18:5
+// CHECK-NEXT: Found variable: var3 -> global_var3 at 19:14
+// CHECK-NEXT: Found variable: ll -> global_ll at 20:21
+// CHECK-NEXT: Found variable: a -> param_a at 21:13
+// CHECK-NEXT: Found variable: b -> param_b at 21:20
+// CHECK-NEXT: Found variable: var2 -> static_var2 at 22:14
+// CHECK-NEXT: Found variable: var3 -> local_var3 at 23:7
+// CHECK-NEXT: Found variable: var2 -> static_var2 at 24:5
+// CHECK-NEXT: Found variable: a -> param_a at 25:10
+// CHECK-NEXT: Found variable: b -> param_b at 25:14
+// CHECK-NEXT: Found variable: var1 -> global_var1 at 25:18
+// CHECK-NEXT: Found variable: var2 -> static_var2 at 25:25
+// CHECK-NEXT: Found variable: var3 -> local_var3 at 25:32
+// CHECK-NEXT: Found variable: ll -> global_ll at 25:39
+
+int var1 = 0;
+extern float var3;
+constexpr long long ll = 1L;
+int foo(int a, int b) {
+  static int var2 = 0;
+  int var3 = 123;
+  ++var2;
+  return a + b + var1 + var2 + var3 + ll;
+}

--- a/clang/test/compiler-course/Shurigin_S_FI1_ClangAst_var4_test/ShuriginS_AST.cpp
+++ b/clang/test/compiler-course/Shurigin_S_FI1_ClangAst_var4_test/ShuriginS_AST.cpp
@@ -1,0 +1,31 @@
+﻿// RUN: %clang_cc1 -load %llvmshlibdir/ClangAST_1_ShuriginS_FIIT1_ClangAST%pluginext -plugin ClangAST_1_ShuriginS_FIIT1_ClangAST -fsyntax-only %s 2>&1 | FileCheck --match-full-lines %s
+
+// CHECK: int static global_Var1 = 0;
+// CHECK-NEXT: extern int global_Var3;
+// CHECK-NEXT: int rA(int param_A) {
+// CHECK-NEXT:   return -param_A;
+// CHECK-NEXT: }
+// CHECK-NEXT: int static foo(int param_A, int param_B) {
+// CHECK-NEXT:   static int static_Var2 = 0;
+// CHECK-NEXT:   int local_Var3 = 123;
+// CHECK-NEXT:   int &local_rA = param_A;
+// CHECK-NEXT:   ++static_Var2;
+// CHECK-NEXT:   return local_rA + param_B + global_Var1 + static_Var2 + local_Var3;
+// CHECK-NEXT: }
+// CHECK-NEXT: int static global_X = foo(1, rA(global_Var3));
+
+int static Var1 = 0;
+extern int Var3;
+int rA(int A) {
+  return -A;
+}
+int static foo(int A, int B) {
+  static int Var2 = 0;
+  int Var3 = 123;
+  int &rA = A;
+  ++Var2;
+  return rA + B + Var1 + Var2 + Var3;
+}
+int static X = foo(1, rA(Var3));
+
+

--- a/clang/test/compiler-course/beskhmelnova_k_implicit_conversions/beskhmelnova_k_implicit_conversions_test.cpp
+++ b/clang/test/compiler-course/beskhmelnova_k_implicit_conversions/beskhmelnova_k_implicit_conversions_test.cpp
@@ -1,0 +1,50 @@
+// RUN: %clang_cc1 -load %llvmshlibdir/ClangAST_1_BeskhmelnovaK_FIIT1_ClangAST%pluginext -plugin ClangAST_1_BeskhmelnovaK_FIIT1_ClangAST -fsyntax-only %s 2>&1 | FileCheck --match-full-lines %s
+
+// Проверка порядка выводимых строк:
+// CHECK: Function sum
+// CHECK-NEXT: float -> double: 1
+// CHECK-NEXT: int -> float: 1
+
+double sum(int a, float b) {
+    return a + b;
+}
+
+// CHECK: Function mul
+// CHECK-NEXT: double -> int: 1
+// CHECK-NEXT: float -> double: 1
+// CHECK-NEXT: float -> int: 1
+
+int mul(float a, float b) {
+    return a + sum(a, b);
+}
+
+// CHECK: Function createX
+// CHECK-NEXT: int -> X: 1
+
+class X {
+    int x;
+public:
+    X(int val) : x(val) {}
+};
+
+X createX() {
+    return 10;
+}
+
+// CHECK: Function foo
+// CHECK-NEXT: int -> float: 1
+// CHECK-NEXT: float -> int: 1
+// CHECK-NEXT: int * -> void *: 1
+
+using Abrakadabra = float;
+using Boom = int;
+
+void boo(void*);
+
+void foo() {
+  Abrakadabra x = Boom();
+  Boom y = x;
+  boo(&y);
+}
+
+// CHECK: Total implicit conversions: 9

--- a/clang/test/compiler-course/chistov_a_user_data_type/chistov_a_user_data_type_test.cpp
+++ b/clang/test/compiler-course/chistov_a_user_data_type/chistov_a_user_data_type_test.cpp
@@ -1,0 +1,92 @@
+// RUN: %clang_cc1 -load %llvmshlibdir/PrintData_Chistov_Alexey_FIIT1_ClangAST%pluginext -plugin PrintDataPlugin %s -fsyntax-only 2>&1 | FileCheck %s
+
+// CHECK: A(class)
+class A {};
+
+// CHECK: B(struct)
+// CHECK-NEXT: |_Fields
+// CHECK-NEXT: | |_ a (A|public)
+struct B {
+    A a;
+};
+
+// CHECK: Simple(struct)
+// CHECK-NEXT: |_Fields
+// CHECK-NEXT: | |_ x (int|public)
+// CHECK-NEXT: | |_ y (double|public)
+// CHECK-NEXT: |_Methods
+// CHECK-NEXT: | |_ method (int|public)
+struct Simple {
+    int x;
+    double y;
+
+    int method(int x, int y) {}
+};
+
+// CHECK: Static(class)
+// CHECK-NEXT: |_Methods
+// CHECK-NEXT: | |_ method (void|private|static)
+class Static {
+    static void method() {}
+};
+
+// CHECK: Template(class|template)
+// CHECK-NEXT: |_Fields
+// CHECK-NEXT: | |_ x (T|private)
+// CHECK-NEXT: | |_ z (int|private)
+template <typename T>
+class Template {
+    T x;
+    int z;
+};
+
+// CHECK: MultiTemplate(class|template)
+// CHECK-NEXT: |_Fields
+// CHECK-NEXT: | |_ first (T|private)
+// CHECK-NEXT: | |_ second (U|private)
+template <typename T, typename U>
+class MultiTemplate {
+    T first;
+    U second;
+};
+
+// CHECK: C -> public A
+// CHECK: C -> public B
+class C : public A, public B {};
+
+// CHECK: PublicDerived -> public Base
+// CHECK: ProtectedDerived -> protected Base
+// CHECK: PrivateDerived -> private Base
+class Base {};
+class PublicDerived : public Base {};
+class ProtectedDerived : protected Base {};
+class PrivateDerived : private Base {};
+
+// CHECK: AccessModifiers
+// CHECK-NEXT: |_Fields
+// CHECK-NEXT: | |_ x (float|private)
+// CHECK-NEXT: | |_ y (double|protected)
+// CHECK-NEXT: | |_ z (long long|public)
+class AccessModifiers {
+private:
+    float x;
+protected:
+    double y;
+public:
+    long long z;
+};
+
+// CHECK: Person
+// CHECK: |_Fields
+// CHECK: | |_ age (unsigned int|public)
+// CHECK: | |_ height (unsigned int|public)
+// CHECK: |_Methods
+// CHECK: | |_ sleep (void|public|virtual|pure)
+// CHECK: | |_ eat (void|public|virtual|pure)
+struct Person {
+    unsigned age;
+    unsigned height;
+
+    virtual void sleep() = 0;
+    virtual void eat() = 0;
+};

--- a/clang/test/compiler-course/kurakin_user_data_type/kurakin_user_data_type_test.cpp
+++ b/clang/test/compiler-course/kurakin_user_data_type/kurakin_user_data_type_test.cpp
@@ -1,0 +1,112 @@
+// RUN: %clang_cc1 -load %llvmshlibdir/UserDataTypePlugin_Kurakin_Matvey_FIIT1_ClangAST%pluginext -plugin UserDataTypePlugin_Kurakin_Matvey_FIIT1_ClangAST -fsyntax-only %s 2>&1 | FileCheck %s
+
+//CHECK: Human
+//CHECK-NEXT: |_Fields
+//CHECK-NEXT: | |_ age (unsigned int|public)
+//CHECK-NEXT: | |_ height (unsigned int|public)
+//CHECK-NEXT: |
+//CHECK-NEXT: |_Methods
+//CHECK-NEXT: | |_ sleep (void()|public|virtual|pure)
+//CHECK-NEXT: | |_ eat (void()|public|virtual|pure)
+
+struct Human {
+  unsigned age;
+  unsigned height;
+  virtual void sleep() = 0;
+  virtual void eat() = 0;
+};
+
+//CHECK: Engineer -> Human
+//CHECK-NEXT: |_Fields
+//CHECK-NEXT: | |_ salary (unsigned int|public)
+//CHECK-NEXT: |
+//CHECK-NEXT: |_Methods
+//CHECK-NEXT: | |_ sleep (void()|public|override)
+//CHECK-NEXT: | |_ eat (void()|public|override)
+//CHECK-NEXT: | |_ work (void()|public)
+
+struct Engineer : Human {
+  unsigned salary;
+  void sleep() override { /* something */ }
+  void eat() override { /* something */ }
+  void work() { /* something */ }
+};
+
+//CHECK: A
+//CHECK-NEXT: |_Fields
+//CHECK-NEXT: | |_ a1 (int|private)
+//CHECK-NEXT: | |_ a2 (float|private)
+//CHECK-NEXT: |
+//CHECK-NEXT: |_Methods
+//CHECK-NEXT: | |_ somefunc (int(float)|private)
+
+class A {
+  int a1;
+  float a2;
+  int somefunc(float);
+};
+
+//CHECK: B
+//CHECK-NEXT: |_Fields
+//CHECK-NEXT: | |_ (has no fields)
+//CHECK-NEXT: |
+//CHECK-NEXT: |_Methods
+//CHECK-NEXT: | |_ b1 (void(int,int)|private|virtual)
+
+class B {
+  virtual void b1(int b2, int b3);
+};
+
+//CHECK: C -> A,B
+//CHECK-NEXT: |_Fields
+//CHECK-NEXT: | |_ (has no fields)
+//CHECK-NEXT: |
+//CHECK-NEXT: |_Methods
+//CHECK-NEXT: | |_ b1 (void(int,int)|private|override)
+//CHECK-NEXT: | |_ somefunc (int(float)|private)
+
+class C : A,B{
+  void b1(int b2, int b3) override;
+  int somefunc(float);
+};
+
+//CHECK: D
+//CHECK-NEXT: |_Fields
+//CHECK-NEXT: | |_ d1 (int[5]|private)
+//CHECK-NEXT: | |_ d2 (T|protected)
+//CHECK-NEXT: |
+//CHECK-NEXT: |_Methods
+//CHECK-NEXT: | |_ d3 (T(T,int)|public|virtual|pure)
+
+template <typename T>
+struct D{
+private:
+  int d1[5];
+protected:
+  T d2;
+public:
+  virtual T d3(T d4, int d5) = 0;
+};
+
+
+//CHECK: E
+//CHECK-NEXT: |_Fields
+//CHECK-NEXT: | |_ (has no fields)
+//CHECK-NEXT: |
+//CHECK-NEXT: |_Methods
+//CHECK-NEXT: | |_ e2 (char(char)|public|static)
+
+struct E{
+  static char e2(char);
+};
+
+//CHECK: F
+//CHECK-NEXT: |_Fields
+//CHECK-NEXT: | |_ f1 (int|private)
+//CHECK-NEXT: |
+//CHECK-NEXT: |_Methods
+//CHECK-NEXT: | |_ (has no methods)
+
+class F{
+  int f1;
+};

--- a/clang/test/compiler-course/lopatin_i_user_data_type/lopatin_i_user_data_type_test.cpp
+++ b/clang/test/compiler-course/lopatin_i_user_data_type/lopatin_i_user_data_type_test.cpp
@@ -1,0 +1,62 @@
+// RUN: %clang_cc1 -load %llvmshlibdir/UserDataTypePlugin_LopatinIlya_FIIT3_ClangAST%pluginext -plugin UserDataTypePlugin_LopatinIlya_FIIT3_ClangAST %s -fsyntax-only 2>&1 | FileCheck %s
+
+// CHECK: Base1
+// CHECK-NEXT: |_Fields
+// CHECK-NEXT: | |_ (no fields)
+// CHECK-NEXT: |_Methods
+// CHECK-NEXT: | |_ virtualMethod (void()|public|virtual|pure)
+
+// CHECK: Base2
+// CHECK-NEXT: |_Fields
+// CHECK-NEXT: | |_ (no fields)
+// CHECK-NEXT: |_Methods
+// CHECK-NEXT: | |_ baseMethod (void()|public|virtual)
+
+// CHECK: Derived -> Base1, Base2
+// CHECK-NEXT: |_Fields
+// CHECK-NEXT: | |_ publicField (int|public)
+// CHECK-NEXT: | |_ protectedField (float|protected)
+// CHECK-NEXT: | |_ privateField (char|private)
+// CHECK-NEXT: |_Methods
+// CHECK-NEXT: | |_ virtualMethod (void()|public|override)
+// CHECK-NEXT: | |_ baseMethod (void()|public|override)
+// CHECK-NEXT: | |_ constMethod (int()|private|const)
+// CHECK-NEXT: | |_ anotherMethod (void(int)|protected)
+
+// CHECK: Array
+// CHECK-NEXT: |_Fields
+// CHECK-NEXT: | |_ ptr (T[SZ]|public)
+
+
+struct Base1 {
+  virtual void virtualMethod() = 0;
+};
+
+struct Base2 {
+  virtual void baseMethod() {}
+};
+
+struct Derived : Base1, Base2 {
+public:
+  int publicField;
+protected:
+  float protectedField;
+private:
+  char privateField;
+
+public:
+  void virtualMethod() override {}
+  void baseMethod() override {}
+  
+private:
+  int constMethod() const { return 0; }
+  
+protected:
+  void anotherMethod(int) {}
+};
+
+template <typename T, unsigned SZ>
+struct Array {
+  T ptr[SZ]{};
+};
+

--- a/clang/test/compiler-course/shishkarev_a_implicit_conversions/shishkarev_a_implicit_conversions_test.cpp
+++ b/clang/test/compiler-course/shishkarev_a_implicit_conversions/shishkarev_a_implicit_conversions_test.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -load %llvmshlibdir/ImplicitConversionCounter_Ivanov_Ivan_FIIT0_ClangAST%pluginext -plugin implicit_conversion_plugin -fsyntax-only %s 2>&1 | FileCheck %s
+// RUN: %clang_cc1 -load %llvmshlibdir/ImplicitConversionCounter_Shishkarev_Andrey_FIIT2_ClangAST%pluginext -plugin implicit_conversion_plugin -fsyntax-only %s 2>&1 | FileCheck %s
 
 // CHECK: Function `sum`
 // CHECK-NEXT: int -> float: 1

--- a/clang/test/compiler-course/shishkarev_a_implicit_conversions/shishkarev_a_implicit_conversions_test.cpp
+++ b/clang/test/compiler-course/shishkarev_a_implicit_conversions/shishkarev_a_implicit_conversions_test.cpp
@@ -1,0 +1,18 @@
+// RUN: %clang_cc1 -load %llvmshlibdir/ImplicitConversionCounter_Ivanov_Ivan_FIIT0_ClangAST%pluginext -plugin implicit_conversion_plugin -fsyntax-only %s 2>&1 | FileCheck %s
+
+// CHECK: Function `sum`
+// CHECK-NEXT: int -> float: 1
+// CHECK-NEXT: float -> double: 1
+
+// CHECK: Function `mul`
+// CHECK-NEXT: float -> int: 1
+// CHECK-NEXT: float -> double: 1
+// CHECK-NEXT: double -> int: 1
+
+double sum(int a, float b) {
+    return a + b;
+}
+
+int mul(float a, float b) {
+    return a + sum(a, b);
+}


### PR DESCRIPTION
Плагин для Clang, который анализирует код и выводит количество неявных преобразований типов для каждой функции. Плагин состоит из двух основных компонентов:

ImplicitConversionVisitor:
1) Обходит все неявные преобразования типов (например, int → float, float → double и т.д.) в теле функций.
2) Сохраняет информацию о каждом преобразовании в виде пары типов (исходный тип → конечный тип).
3) Удаляет дубликаты преобразований и преобразования внутри одного типа (например, int → int).
4) Выводит количество уникальных преобразований для каждой функции в формате:
          Function `имя_функции`
          исходный_тип -> конечный_тип: количество
FunctionDumpVisitor:
1) Обходит все функции и выводит их AST (абстрактное синтаксическое дерево) для проверки корректности работы плагина.
2) Убеждается, что плагин корректно обрабатывает все неявные преобразования и выводит их в правильном порядке.
Порядок работы:
1) Сначала вызывается ImplicitConversionVisitor, который находит и подсчитывает все неявные преобразования типов.
2) Затем вызывается FunctionDumpVisitor, который выводит AST функций для проверки корректности работы плагина.
