### PR TITLE
Романов Артем. 3823Б1ФИ3. Вариант 3.

### DIFF
--- a/.github/deadline.py
+++ b/.github/deadline.py
@@ -1,35 +1,44 @@
 import os
 import sys
 from github import Github
-from datetime import datetime
+from datetime import datetime, timedelta
 from zoneinfo import ZoneInfo
 
 
 def main():
     moscow_tz = ZoneInfo("Europe/Moscow")
-    current_date = datetime.now(moscow_tz)
-    deadline_date = {
+    deadlines = {
         "lab:clang": datetime(2026, 3, 17, hour=19, tzinfo=moscow_tz),
         "lab:llvm ir": datetime(2099, 6, 1, hour=19, tzinfo=moscow_tz),
         "lab:backend": datetime(2099, 6, 1, hour=19, tzinfo=moscow_tz),
         "lab:mlir": datetime(2099, 6, 1, hour=19, tzinfo=moscow_tz),
     }
+    lab_labels = ["lab:clang", "lab:llvm ir", "lab:backend", "lab:mlir"]
 
     gh = Github(os.environ["GITHUB_TOKEN"])
     repo = gh.get_repo(os.environ["GITHUB_REPOSITORY"])
     pr = repo.get_pull(int(os.environ["PR_NUMBER"]))
-    labels = ["lab:clang", "lab:llvm ir", "lab:backend", "lab:mlir"]
-    lab_label = None
-
-    for label in pr.get_labels():
-        if label.name in labels:
-            lab_label = label.name
+    current_labels = [label.name for label in pr.get_labels()]
+    lab_label = next((l for l in current_labels if l in lab_labels), None)
 
     if not lab_label:
         return
 
-    if current_date > deadline_date[lab_label]:
-        pr.add_to_labels("delayed")
+    pr_created_date = pr.created_at.astimezone(moscow_tz)
+    current_date = datetime.now(moscow_tz)
+    deadline_date = deadlines[lab_label]
+    time_before_deadline = deadline_date - pr_created_date
+    LABEL_LOW_PRIORITY = "low priority"
+    LABEL_DELAYED = "delayed"
+
+    if current_date > deadline_date:
+        if LABEL_DELAYED not in current_labels:
+            pr.add_to_labels(LABEL_DELAYED)
+        if LABEL_LOW_PRIORITY in current_labels:
+            pr.remove_from_labels(LABEL_LOW_PRIORITY)
+    elif time_before_deadline < timedelta(hours=72):
+        if LABEL_LOW_PRIORITY not in current_labels:
+            pr.add_to_labels(LABEL_LOW_PRIORITY)
 
 
 if __name__ == "__main__":

--- a/.github/workflows/compiler-course-build.yml
+++ b/.github/workflows/compiler-course-build.yml
@@ -38,41 +38,6 @@ jobs:
             check-llvm-compiler-course \
             check-clang-compiler-course \
             check-mlir-compiler-course -j $(nproc)
-  macos-build:
-    runs-on: macOS-latest
-    strategy:
-      matrix:
-        assertions: [ON, OFF]
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-      - name: Setup environment
-        run: |
-          brew install \
-            ninja
-      - name: Setup ccache
-        uses: hendrikmuhs/ccache-action@v1.2
-        with:
-          max-size: 500M
-          key: ccache-${{ github.job }}
-      - name: Build
-        run: |
-          cmake -S llvm -B build \
-            -DCMAKE_BUILD_TYPE=Release \
-            -DLLVM_ENABLE_PROJECTS="clang;mlir" \
-            -DLLVM_ENABLE_ASSERTIONS=${{ matrix.assertions }} \
-            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
-            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-            -DLLVM_TARGETS_TO_BUILD="X86;AArch64" \
-            -G Ninja
-          cmake --build build --config Release -j $(nproc)
-      - name: Test
-        run: |
-          cmake --build build --config Release -t \
-            check-llvm-compiler-course \
-            check-clang-compiler-course \
-            check-mlir-compiler-course -j $(nproc)
   windows-build:
     runs-on: windows-latest
     strategy:

--- a/.github/workflows/compiler-course-build.yml
+++ b/.github/workflows/compiler-course-build.yml
@@ -1,6 +1,10 @@
 name: Build LLVM
 on: [push, pull_request]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/course-spring-2026' && github.event_name != 'merge_group' && !startsWith(github.ref, 'refs/heads/gh-readonly-queue') }}
+
 jobs:
   ubuntu-gcc-build:
     runs-on: ubuntu-latest

--- a/.github/workflows/compiler-course-static-analysis.yml
+++ b/.github/workflows/compiler-course-static-analysis.yml
@@ -1,0 +1,17 @@
+name: Static analysis
+on: [pull_request]
+
+jobs:
+  clang-format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Install clang-format
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang-format
+      - name: Run clang-format
+        run: |
+          git-clang-format --diff `git merge-base ${GITHUB_SHA} origin/${GITHUB_BASE_REF}`

--- a/clang/compiler-course/kutergin_valentin_3823b1fi3/CMakeLists.txt
+++ b/clang/compiler-course/kutergin_valentin_3823b1fi3/CMakeLists.txt
@@ -1,0 +1,18 @@
+set(Title "NoexceptSpecificatorPlugin")
+set(Student "Kutergin_Valentin")
+set(Group "FIIT3")
+set(TARGET_NAME "${Title}_${Student}_${Group}_ClangAST")
+
+file(GLOB_RECURSE SOURCES *.cpp *.h *.hpp)
+add_llvm_library(${TARGET_NAME} MODULE ${SOURCES} PLUGIN_TOOL clang)
+
+if(WIN32 OR CYGWIN)
+    set(LLVM_LINK_COMPONENTS Support)
+    clang_target_link_libraries(${TARGET_NAME} PRIVATE
+        clangAST
+        clangBasic
+        clangFrontend
+    )
+endif()
+
+set(CLANG_TEST_DEPS "${TARGET_NAME}" ${CLANG_TEST_DEPS} PARENT_SCOPE)

--- a/clang/compiler-course/kutergin_valentin_3823b1fi3/source.cpp
+++ b/clang/compiler-course/kutergin_valentin_3823b1fi3/source.cpp
@@ -1,0 +1,83 @@
+#include "clang/AST/ASTConsumer.h"
+#include "clang/AST/RecursiveASTVisitor.h"
+#include "clang/Frontend/CompilerInstance.h"
+#include "clang/Frontend/FrontendPluginRegistry.h"
+#include "llvm/Support/raw_ostream.h"
+
+namespace {
+class ThrowDetector final : public clang::RecursiveASTVisitor<ThrowDetector> {
+public:
+    bool canThrow = false;
+
+    bool VisitCXXThrowExpr(clang::CXXThrowExpr *E) {
+        canThrow = true;
+        return false;
+    }
+
+    bool VisitCallExpr(clang::CallExpr *E) {
+        if (clang::FunctionDecl *Callee = E->getDirectCallee()) {
+            const auto *Proto = Callee->getType()->getAs<clang::FunctionProtoType>();
+            if (!Proto || Proto->getExceptionSpecType() == clang::EST_None) {
+                canThrow = true;
+                return false;
+            }
+        }
+        return true;
+    }
+};
+
+class NoexceptVisitor final : public clang::RecursiveASTVisitor<NoexceptVisitor> {
+public:
+    explicit NoexceptVisitor(clang::ASTContext &C) : Context(C) {}
+    
+    bool VisitFunctionDecl(clang::FunctionDecl *FD) {
+        if (!FD->hasBody())
+            return true;
+
+        const auto *FPT = FD->getType()->getAs<clang::FunctionProtoType>();
+        if (!FPT || FPT->getExceptionSpecType() != clang::EST_None)
+            return true;
+
+        ThrowDetector Detector;
+        Detector.TraverseStmt(FD->getBody());
+
+        if (!Detector.canThrow) {
+            clang::FunctionProtoType::ExtProtoInfo EPI = FPT->getExtProtoInfo();
+            EPI.ExceptionSpec.Type = clang::EST_BasicNoexcept;
+
+            clang::QualType NewType = Context.getFunctionType(FPT->getReturnType(), FPT->getParamTypes(), EPI);
+
+            FD->setType(NewType);
+        }
+        return true;
+    }
+private:
+    clang::ASTContext &Context;
+};
+
+class NoexceptConsumer final : public clang::ASTConsumer {
+public:
+    void HandleTranslationUnit(clang::ASTContext &Context) override {
+        NoexceptVisitor Visitor(Context);
+        Visitor.TraverseDecl(Context.getTranslationUnitDecl());
+    }
+};
+
+class NoexceptAction final : public clang::PluginASTAction {
+public:
+    std::unique_ptr<clang::ASTConsumer> CreateASTConsumer(clang::CompilerInstance &ci, llvm::StringRef) override {
+        return std::make_unique<NoexceptConsumer>();
+    }
+
+    bool ParseArgs(const clang::CompilerInstance &ci, const std::vector<std::string> &args) override {
+        return true;
+    }
+
+    ActionType getActionType() override {
+        return AddBeforeMainAction;
+    }
+};
+} // namespace
+
+static clang::FrontendPluginRegistry::Add<NoexceptAction> 
+    X("kutergin_valentin_3823b1fi3", "NoexceptSpecificatorPlugin");

--- a/clang/compiler-course/lukin_i_lab1/CMakeLists.txt
+++ b/clang/compiler-course/lukin_i_lab1/CMakeLists.txt
@@ -1,0 +1,18 @@
+set(Title "VariableStatisticsPlugin")
+set(Student "Lukin_Ivan")
+set(Group "FIIT3")
+set(TARGET_NAME "${Title}_${Student}_${Group}_ClangAST")
+
+file(GLOB_RECURSE SOURCES *.cpp *.h *.hpp)
+add_llvm_library(${TARGET_NAME} MODULE ${SOURCES} PLUGIN_TOOL clang)
+
+if(WIN32 OR CYGWIN)
+    set(LLVM_LINK_COMPONENTS Support)
+    clang_target_link_libraries(${TARGET_NAME} PRIVATE
+        clangAST
+        clangBasic
+        clangFrontend
+    )
+endif()
+
+set(CLANG_TEST_DEPS "${TARGET_NAME}" ${CLANG_TEST_DEPS} PARENT_SCOPE)

--- a/clang/compiler-course/lukin_i_lab1/source.cpp
+++ b/clang/compiler-course/lukin_i_lab1/source.cpp
@@ -1,0 +1,92 @@
+#include "clang/AST/ASTConsumer.h"
+#include "clang/AST/RecursiveASTVisitor.h"
+#include "clang/Frontend/CompilerInstance.h"
+#include "clang/Frontend/FrontendPluginRegistry.h"
+#include "llvm/Support/raw_ostream.h"
+
+namespace {
+
+struct Statistic // здесь будет храниться статистика по переменным
+{
+  int global_obj = 0;
+  int static_vars = 0;
+  int local_vars = 0;
+  int params = 0;
+};
+
+class StatisticVisitor final
+    : public clang::RecursiveASTVisitor<StatisticVisitor> {
+public:
+  explicit StatisticVisitor(clang::ASTContext *context)
+      : m_context(context), stat(Statistic()) {}
+
+  // вызывается, когда доходим до пар-в ф-ии
+  bool VisitParmVarDecl(clang::ParmVarDecl *D) {
+    stat.params++;
+    return true;
+  }
+
+  // вызывается, когда доходим до обьявления переменных
+  bool VisitVarDecl(clang::VarDecl *D) {
+    // т.к. пар-ры ф-ии также явл-ся переменными, проверяем, не они ли это.
+    // Иначе посчитаем дважды
+    if (clang::isa<clang::ParmVarDecl>(D)) {
+      return true;
+    }
+
+    if (D->getStorageClass() == clang::SC_Static || D->isStaticDataMember()) {
+      stat.static_vars++;
+    } else if (D->isFileVarDecl()) {
+      stat.global_obj++;
+    } else if (D->isLocalVarDecl()) {
+      stat.local_vars++;
+    }
+
+    return true;
+  }
+
+  Statistic get_statistic() const { return stat; }
+
+private:
+  clang::ASTContext *m_context;
+  Statistic stat;
+};
+
+class StatisticConsumer final : public clang::ASTConsumer {
+public:
+  explicit StatisticConsumer(clang::ASTContext *context) : m_visitor(context) {}
+
+  void HandleTranslationUnit(clang::ASTContext &context) override {
+    m_visitor.TraverseDecl(context.getTranslationUnitDecl());
+
+    Statistic stat = m_visitor.get_statistic();
+
+    auto &out = llvm::outs();
+    out << "\nStatistics\n";
+    out << "Global objects: " << stat.global_obj << "\n";
+    out << "Local variables: " << stat.local_vars << "\n";
+    out << "Static variables: " << stat.static_vars << "\n";
+    out << "Params: " << stat.params << "\n";
+  }
+
+private:
+  StatisticVisitor m_visitor;
+};
+
+class StatisticAction final : public clang::PluginASTAction {
+public:
+  std::unique_ptr<clang::ASTConsumer>
+  CreateASTConsumer(clang::CompilerInstance &ci, llvm::StringRef) override {
+    return std::make_unique<StatisticConsumer>(&ci.getASTContext());
+  }
+
+  bool ParseArgs(const clang::CompilerInstance &ci,
+                 const std::vector<std::string> &args) override {
+    return true;
+  }
+};
+} // namespace
+
+static clang::FrontendPluginRegistry::Add<StatisticAction>
+    X("VariableStatisticsPlugin",
+      "Plugin for obtaining statistics on variables in TU");

--- a/clang/compiler-course/romanov_a_cast_replace/CMakeLists.txt
+++ b/clang/compiler-course/romanov_a_cast_replace/CMakeLists.txt
@@ -1,0 +1,16 @@
+get_filename_component(CURRENT_DIR_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+set(TARGET_NAME "${CURRENT_DIR_NAME}_ClangAST")
+
+file(GLOB_RECURSE SOURCES *.cpp *.h *.hpp)
+add_llvm_library(${TARGET_NAME} MODULE ${SOURCES} PLUGIN_TOOL clang)
+
+if(WIN32 OR CYGWIN)
+    set(LLVM_LINK_COMPONENTS Support)
+    clang_target_link_libraries(${TARGET_NAME} PRIVATE
+        clangAST
+        clangBasic
+        clangFrontend
+    )
+endif()
+
+set(CLANG_TEST_DEPS "${TARGET_NAME}" ${CLANG_TEST_DEPS} PARENT_SCOPE)

--- a/clang/compiler-course/romanov_a_cast_replace/source.cpp
+++ b/clang/compiler-course/romanov_a_cast_replace/source.cpp
@@ -2,50 +2,48 @@
 #include "clang/AST/RecursiveASTVisitor.h"
 #include "clang/Frontend/CompilerInstance.h"
 #include "clang/Frontend/FrontendPluginRegistry.h"
-#include "llvm/Support/raw_ostream.h"
 #include "clang/Lex/Lexer.h"
 #include "clang/Rewrite/Core/Rewriter.h"
-
-#include <string>
+#include "llvm/Support/raw_ostream.h"
 
 namespace {
 
 static std::string getCppCastWord(const clang::CStyleCastExpr *expr) {
   switch (expr->getCastKind()) {
 
-case clang::CK_BitCast:
-case clang::CK_LValueBitCast:
-case clang::CK_LValueToRValueBitCast: {
+  case clang::CK_BitCast:
+  case clang::CK_LValueBitCast:
+  case clang::CK_LValueToRValueBitCast: {
     clang::QualType src = expr->getSubExpr()->getType();
     clang::QualType dst = expr->getType();
 
-    // void* → T* and T* → void* 
+    // void* → T* and T* → void* will be replaced with static_cast
     if ((src->isPointerType() && src->getPointeeType()->isVoidType()) ||
         (dst->isPointerType() && dst->getPointeeType()->isVoidType())) {
-        return "static_cast";
+      return "static_cast";
     }
     return "reinterpret_cast";
-}
+  }
 
-case clang::CK_IntegralToPointer:
-case clang::CK_PointerToIntegral:
-case clang::CK_ReinterpretMemberPointer:
+  case clang::CK_ReinterpretMemberPointer:
+  case clang::CK_IntegralToPointer:
+  case clang::CK_PointerToIntegral:
     return "reinterpret_cast";
 
   case clang::CK_NoOp: {
-      clang::QualType src = expr->getSubExpr()->getType();
-      clang::QualType dst = expr->getType();
+    clang::QualType src = expr->getSubExpr()->getType();
+    clang::QualType dst = expr->getType();
 
-      if (src->isPointerType() && dst->isPointerType()) {
-          src = src->getPointeeType();
-          dst = dst->getPointeeType();
-      }
+    if (src->isPointerType() && dst->isPointerType()) {
+      src = src->getPointeeType();
+      dst = dst->getPointeeType();
+    }
 
-      if (src.isConstQualified()    != dst.isConstQualified() ||
-          src.isVolatileQualified() != dst.isVolatileQualified()) {
-          return "const_cast";
-      }
-      return "static_cast";
+    if (src.isConstQualified() != dst.isConstQualified() ||
+        src.isVolatileQualified() != dst.isVolatileQualified()) {
+      return "const_cast";
+    }
+    return "static_cast";
   }
 
   default:
@@ -53,34 +51,44 @@ case clang::CK_ReinterpretMemberPointer:
   }
 }
 
-class RomanovACastReplaceVisitor final : public clang::RecursiveASTVisitor<RomanovACastReplaceVisitor> {
+class RomanovACastReplaceVisitor final
+    : public clang::RecursiveASTVisitor<RomanovACastReplaceVisitor> {
 public:
-  explicit RomanovACastReplaceVisitor(clang::ASTContext *context, clang::Rewriter &rewriter): m_context(context), m_rewriter(rewriter) {}
+  explicit RomanovACastReplaceVisitor(clang::ASTContext *context,
+                                      clang::Rewriter &rewriter)
+      : m_context(context), m_rewriter(rewriter) {}
 
   bool shouldTraversePostOrder() const { return true; }
 
   bool VisitCStyleCastExpr(clang::CStyleCastExpr *expr) {
     std::string cast_keyword = getCppCastWord(expr);
-    std::string cast_type_keyword = expr->getTypeAsWritten().getAsString(m_context->getPrintingPolicy());
+    std::string cast_type_keyword =
+        expr->getTypeAsWritten().getAsString(m_context->getPrintingPolicy());
 
     clang::Expr *sub_expr = expr->getSubExprAsWritten();
-    std::string sub_expr_text = m_rewriter.getRewrittenText(clang::CharSourceRange::getTokenRange(sub_expr->getSourceRange()));
+    std::string sub_expr_text = m_rewriter.getRewrittenText(
+        clang::CharSourceRange::getTokenRange(sub_expr->getSourceRange()));
 
-    std::string replacement_cast = cast_keyword + "<" + cast_type_keyword + ">(" + sub_expr_text + ")";
+    std::string replacement_cast =
+        cast_keyword + "<" + cast_type_keyword + ">(" + sub_expr_text + ")";
 
-    m_rewriter.ReplaceText(clang::CharSourceRange::getTokenRange(expr->getSourceRange()), replacement_cast);
+    m_rewriter.ReplaceText(
+        clang::CharSourceRange::getTokenRange(expr->getSourceRange()),
+        replacement_cast);
 
     return true;
   }
 
 private:
   clang::ASTContext *m_context;
-  clang::Rewriter   &m_rewriter;
+  clang::Rewriter &m_rewriter;
 };
 
 class RomanovACastReplaceConsumer final : public clang::ASTConsumer {
 public:
-  explicit RomanovACastReplaceConsumer(clang::ASTContext *context, clang::Rewriter &rewriter): m_visitor(context, rewriter) {}
+  explicit RomanovACastReplaceConsumer(clang::ASTContext *context,
+                                       clang::Rewriter &rewriter)
+      : m_visitor(context, rewriter) {}
 
   void HandleTranslationUnit(clang::ASTContext &context) override {
     m_visitor.TraverseDecl(context.getTranslationUnitDecl());
@@ -95,15 +103,18 @@ public:
   std::unique_ptr<clang::ASTConsumer>
   CreateASTConsumer(clang::CompilerInstance &ci, llvm::StringRef) override {
     m_rewriter.setSourceMgr(ci.getSourceManager(), ci.getLangOpts());
-    return std::make_unique<RomanovACastReplaceConsumer>(&ci.getASTContext(), m_rewriter);
+    return std::make_unique<RomanovACastReplaceConsumer>(&ci.getASTContext(),
+                                                         m_rewriter);
   }
 
-  bool ParseArgs(const clang::CompilerInstance &, const std::vector<std::string> &) override {
+  bool ParseArgs(const clang::CompilerInstance &,
+                 const std::vector<std::string> &) override {
     return true;
   }
 
   void EndSourceFileAction() override {
-    m_rewriter.getEditBuffer(m_rewriter.getSourceMgr().getMainFileID()).write(llvm::outs());
+    m_rewriter.getEditBuffer(m_rewriter.getSourceMgr().getMainFileID())
+        .write(llvm::outs());
   }
 
 private:
@@ -112,4 +123,5 @@ private:
 } // namespace
 
 static clang::FrontendPluginRegistry::Add<RomanovACastReplaceAction>
-    X("romanov_a_cast_replace_plugin", "Plugin to replace C-style castes in C++-style castes");
+    X("romanov_a_cast_replace_plugin",
+      "Plugin to replace C-style castes in C++-style castes");

--- a/clang/compiler-course/romanov_a_cast_replace/source.cpp
+++ b/clang/compiler-course/romanov_a_cast_replace/source.cpp
@@ -124,4 +124,4 @@ private:
 
 static clang::FrontendPluginRegistry::Add<RomanovACastReplaceAction>
     X("romanov_a_cast_replace_plugin",
-      "Plugin to replace C-style castes in C++-style castes");
+      "Plugin for replacing C-style casts with C++-style castes");

--- a/clang/compiler-course/romanov_a_cast_replace/source.cpp
+++ b/clang/compiler-course/romanov_a_cast_replace/source.cpp
@@ -13,16 +13,40 @@ namespace {
 static std::string getCppCastWord(const clang::CStyleCastExpr *expr) {
   switch (expr->getCastKind()) {
 
-  case clang::CK_BitCast:
-  case clang::CK_LValueBitCast:
-  case clang::CK_LValueToRValueBitCast:
-  case clang::CK_IntegralToPointer:
-  case clang::CK_PointerToIntegral:
-  case clang::CK_ReinterpretMemberPointer:
+case clang::CK_BitCast:
+case clang::CK_LValueBitCast:
+case clang::CK_LValueToRValueBitCast: {
+    clang::QualType src = expr->getSubExpr()->getType();
+    clang::QualType dst = expr->getType();
+
+    // void* → T* and T* → void* 
+    if ((src->isPointerType() && src->getPointeeType()->isVoidType()) ||
+        (dst->isPointerType() && dst->getPointeeType()->isVoidType())) {
+        return "static_cast";
+    }
+    return "reinterpret_cast";
+}
+
+case clang::CK_IntegralToPointer:
+case clang::CK_PointerToIntegral:
+case clang::CK_ReinterpretMemberPointer:
     return "reinterpret_cast";
 
-  case clang::CK_NoOp:
-    return "const_cast";
+  case clang::CK_NoOp: {
+      clang::QualType src = expr->getSubExpr()->getType();
+      clang::QualType dst = expr->getType();
+
+      if (src->isPointerType() && dst->isPointerType()) {
+          src = src->getPointeeType();
+          dst = dst->getPointeeType();
+      }
+
+      if (src.isConstQualified()    != dst.isConstQualified() ||
+          src.isVolatileQualified() != dst.isVolatileQualified()) {
+          return "const_cast";
+      }
+      return "static_cast";
+  }
 
   default:
     return "static_cast";
@@ -33,17 +57,16 @@ class RomanovACastReplaceVisitor final : public clang::RecursiveASTVisitor<Roman
 public:
   explicit RomanovACastReplaceVisitor(clang::ASTContext *context, clang::Rewriter &rewriter): m_context(context), m_rewriter(rewriter) {}
 
-  bool VisitCStyleCastExpr(clang::CStyleCastExpr *expr) {
-    clang::SourceManager &sm        = m_context->getSourceManager();
-    const clang::LangOptions &opts  = m_context->getLangOpts();
+  bool shouldTraversePostOrder() const { return true; }
 
+  bool VisitCStyleCastExpr(clang::CStyleCastExpr *expr) {
     std::string cast_keyword = getCppCastWord(expr);
     std::string cast_type_keyword = expr->getTypeAsWritten().getAsString(m_context->getPrintingPolicy());
 
     clang::Expr *sub_expr = expr->getSubExprAsWritten();
-    clang::StringRef sub_expr_text = clang::Lexer::getSourceText(clang::CharSourceRange::getTokenRange(sub_expr->getSourceRange()), sm, opts);
+    std::string sub_expr_text = m_rewriter.getRewrittenText(clang::CharSourceRange::getTokenRange(sub_expr->getSourceRange()));
 
-    std::string replacement_cast = cast_keyword + "<" + cast_type_keyword + ">(" + sub_expr_text.str() + ")";
+    std::string replacement_cast = cast_keyword + "<" + cast_type_keyword + ">(" + sub_expr_text + ")";
 
     m_rewriter.ReplaceText(clang::CharSourceRange::getTokenRange(expr->getSourceRange()), replacement_cast);
 

--- a/clang/compiler-course/romanov_a_cast_replace/source.cpp
+++ b/clang/compiler-course/romanov_a_cast_replace/source.cpp
@@ -1,0 +1,92 @@
+#include "clang/AST/ASTConsumer.h"
+#include "clang/AST/RecursiveASTVisitor.h"
+#include "clang/Frontend/CompilerInstance.h"
+#include "clang/Frontend/FrontendPluginRegistry.h"
+#include "llvm/Support/raw_ostream.h"
+#include "clang/Lex/Lexer.h"
+#include "clang/Rewrite/Core/Rewriter.h"
+
+#include <string>
+
+namespace {
+
+static std::string getCppCastWord(const clang::CStyleCastExpr *expr) {
+  switch (expr->getCastKind()) {
+
+  case clang::CK_BitCast:
+  case clang::CK_LValueBitCast:
+  case clang::CK_LValueToRValueBitCast:
+  case clang::CK_IntegralToPointer:
+  case clang::CK_PointerToIntegral:
+  case clang::CK_ReinterpretMemberPointer:
+    return "reinterpret_cast";
+
+  case clang::CK_NoOp:
+    return "const_cast";
+
+  default:
+    return "static_cast";
+  }
+}
+
+class RomanovACastReplaceVisitor final : public clang::RecursiveASTVisitor<RomanovACastReplaceVisitor> {
+public:
+  explicit RomanovACastReplaceVisitor(clang::ASTContext *context, clang::Rewriter &rewriter): m_context(context), m_rewriter(rewriter) {}
+
+  bool VisitCStyleCastExpr(clang::CStyleCastExpr *expr) {
+    clang::SourceManager &sm        = m_context->getSourceManager();
+    const clang::LangOptions &opts  = m_context->getLangOpts();
+
+    std::string cast_keyword = getCppCastWord(expr);
+    std::string cast_type_keyword = expr->getTypeAsWritten().getAsString(m_context->getPrintingPolicy());
+
+    clang::Expr *sub_expr = expr->getSubExprAsWritten();
+    clang::StringRef sub_expr_text = clang::Lexer::getSourceText(clang::CharSourceRange::getTokenRange(sub_expr->getSourceRange()), sm, opts);
+
+    std::string replacement_cast = cast_keyword + "<" + cast_type_keyword + ">(" + sub_expr_text.str() + ")";
+
+    m_rewriter.ReplaceText(clang::CharSourceRange::getTokenRange(expr->getSourceRange()), replacement_cast);
+
+    return true;
+  }
+
+private:
+  clang::ASTContext *m_context;
+  clang::Rewriter   &m_rewriter;
+};
+
+class RomanovACastReplaceConsumer final : public clang::ASTConsumer {
+public:
+  explicit RomanovACastReplaceConsumer(clang::ASTContext *context, clang::Rewriter &rewriter): m_visitor(context, rewriter) {}
+
+  void HandleTranslationUnit(clang::ASTContext &context) override {
+    m_visitor.TraverseDecl(context.getTranslationUnitDecl());
+  }
+
+private:
+  RomanovACastReplaceVisitor m_visitor;
+};
+
+class RomanovACastReplaceAction final : public clang::PluginASTAction {
+public:
+  std::unique_ptr<clang::ASTConsumer>
+  CreateASTConsumer(clang::CompilerInstance &ci, llvm::StringRef) override {
+    m_rewriter.setSourceMgr(ci.getSourceManager(), ci.getLangOpts());
+    return std::make_unique<RomanovACastReplaceConsumer>(&ci.getASTContext(), m_rewriter);
+  }
+
+  bool ParseArgs(const clang::CompilerInstance &, const std::vector<std::string> &) override {
+    return true;
+  }
+
+  void EndSourceFileAction() override {
+    m_rewriter.getEditBuffer(m_rewriter.getSourceMgr().getMainFileID()).write(llvm::outs());
+  }
+
+private:
+  clang::Rewriter m_rewriter;
+};
+} // namespace
+
+static clang::FrontendPluginRegistry::Add<RomanovACastReplaceAction>
+    X("romanov_a_cast_replace_plugin", "Plugin to replace C-style castes in C++-style castes");

--- a/clang/compiler-course/votincev_d_analyzer/CMakeLists.txt
+++ b/clang/compiler-course/votincev_d_analyzer/CMakeLists.txt
@@ -1,0 +1,16 @@
+get_filename_component(CURRENT_DIR_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+set(TARGET_NAME "${CURRENT_DIR_NAME}_ClangAST")
+
+file(GLOB_RECURSE SOURCES *.cpp *.h *.hpp)
+add_llvm_library(${TARGET_NAME} MODULE ${SOURCES} PLUGIN_TOOL clang)
+
+if(WIN32 OR CYGWIN)
+    set(LLVM_LINK_COMPONENTS Support)
+    clang_target_link_libraries(${TARGET_NAME} PRIVATE
+        clangAST
+        clangBasic
+        clangFrontend
+    )
+endif()
+
+set(CLANG_TEST_DEPS "${TARGET_NAME}" ${CLANG_TEST_DEPS} PARENT_SCOPE)

--- a/clang/compiler-course/votincev_d_analyzer/votincev_d_analyzer.cpp
+++ b/clang/compiler-course/votincev_d_analyzer/votincev_d_analyzer.cpp
@@ -1,0 +1,224 @@
+#include "clang/AST/ASTConsumer.h"
+#include "clang/AST/RecursiveASTVisitor.h"
+#include "clang/Frontend/CompilerInstance.h"
+#include "clang/Frontend/FrontendPluginRegistry.h"
+#include "llvm/Support/raw_ostream.h"
+
+#include <set>
+#include <vector>
+
+// работа плагина:
+// Action (создает) -> Consumer(запускает) -> Visitor(анализирует)
+
+namespace {
+
+// класс VotincevDVisitor - анализатор
+// просматривает узлы дерева
+class VotincevDVisitor final
+    : public clang::RecursiveASTVisitor<VotincevDVisitor> {
+public:
+  explicit VotincevDVisitor(clang::ASTContext *context) : m_context(context) {}
+
+  // находим ресурсы, которые не гарантированно освобождаются при выходе
+  bool VisitReturnStmt(clang::ReturnStmt *ret) {
+    for (auto *allocVar : m_allocatedVars) {
+      bool found = false;
+      for (auto *deallocVar : m_deallocatedVars) {
+        if (allocVar == deallocVar) {
+          found = true;
+          break;
+        }
+      }
+
+      // если на момент return переменная не в списке освобожденных
+      // и мы о ней еще не сообщали
+      if (!found && m_reportedVars.find(allocVar) == m_reportedVars.end()) {
+        clang::DiagnosticsEngine &DE = m_context->getDiagnostics();
+        unsigned diagID = DE.getCustomDiagID(
+            clang::DiagnosticsEngine::Warning,
+            "Ресурс для переменной '%0' может быть не освобожден (не "
+            "гарантированное освобождение при return)!");
+        DE.Report(ret->getReturnLoc(), diagID) << allocVar->getNameAsString();
+
+        m_reportedVars.insert(allocVar);
+      }
+    }
+    return true;
+  }
+
+  // функция free/fclose?
+  bool VisitCallExpr(clang::CallExpr *call) {
+    clang::FunctionDecl *func = call->getDirectCallee();
+
+    // проверяем, что это не какой-нибудь странный вызов по указателю
+    if (!func) {
+      return true;
+    }
+
+    llvm::StringRef funcName = func->getName();
+    if (funcName == "free" || funcName == "fclose") {
+      clang::Expr *arg = call->getArg(0)->IgnoreParenCasts();
+
+      clang::VarDecl *var = getVarDeclFromExpr(arg);
+
+      // если нашли переменную
+      if (var) {
+        m_deallocatedVars.push_back(var);
+      }
+    }
+
+    return true;
+  }
+
+  bool VisitCXXDeleteExpr(clang::CXXDeleteExpr *del) {
+    clang::Expr *arg = del->getArgument()->IgnoreParenCasts();
+    clang::VarDecl *var = getVarDeclFromExpr(arg);
+    if (var) {
+      m_deallocatedVars.push_back(var);
+    }
+    return true;
+  }
+
+  bool VisitVarDecl(clang::VarDecl *var) {
+    clang::Expr *init = var->getInit();
+    // если инициализация есть и это выделение памяти (malloc/new)
+    if (init && isAllocation(init)) {
+      // Проверка на уникальность, чтобы не дублировать глобальные/локальные
+      if (std::find(m_allocatedVars.begin(), m_allocatedVars.end(), var) ==
+          m_allocatedVars.end()) {
+        m_allocatedVars.push_back(var);
+      }
+    }
+    return true;
+  }
+
+  bool VisitBinaryOperator(clang::BinaryOperator *op) {
+    // если это операция присваивания и справа стоит выделение памяти
+    if (op->isAssignmentOp() && isAllocation(op->getRHS())) {
+      clang::VarDecl *var = getVarDeclFromExpr(op->getLHS());
+      if (var) {
+        // если этой переменной еще нет в списке выделенных - добавляем
+        if (std::find(m_allocatedVars.begin(), m_allocatedVars.end(), var) ==
+            m_allocatedVars.end()) {
+          m_allocatedVars.push_back(var);
+        }
+      }
+    }
+    return true;
+  }
+
+  // функция для сравнения списков и вывода предупреждений
+  void checkLeaks() {
+    for (auto *allocVar : m_allocatedVars) {
+      // если мы уже ругались на эту переменную в VisitReturnStmt — пропускаем
+      if (m_reportedVars.count(allocVar))
+        continue;
+
+      bool found = false; // флаг: нашли ли удаление
+
+      for (auto *deallocVar : m_deallocatedVars) {
+        if (allocVar == deallocVar) {
+          found = true; // нашли, значит утечки нет
+          break;
+        }
+      }
+
+      // если дошли до конца и удаления не нашли
+      if (!found) {
+        clang::DiagnosticsEngine &DE = m_context->getDiagnostics();
+        unsigned diagID = DE.getCustomDiagID(
+            clang::DiagnosticsEngine::Warning,
+            "Память или ресурс для переменной '%0' не освобождены!");
+        DE.Report(allocVar->getLocation(), diagID)
+            << allocVar->getNameAsString();
+      }
+    }
+  }
+
+private:
+  // проверяет, является ли выражение выделением
+  bool isAllocation(clang::Expr *e) {
+    if (!e)
+      return false;
+    clang::Expr *coreExpr = e->IgnoreParenCasts();
+
+    // проверка на вызов функции (malloc/fopen)
+    if (clang::CallExpr *call = clang::dyn_cast<clang::CallExpr>(coreExpr)) {
+      if (clang::FunctionDecl *func = call->getDirectCallee()) {
+        llvm::StringRef funcName = func->getName();
+        return (funcName == "malloc" || funcName == "fopen");
+      }
+    }
+
+    // проверка на оператор new
+    if (clang::isa<clang::CXXNewExpr>(coreExpr)) {
+      return true;
+    }
+
+    return false;
+  }
+
+  // достает VarDecl из любого выражения (ссылки)
+  clang::VarDecl *getVarDeclFromExpr(clang::Expr *e) {
+    if (!e)
+      return nullptr;
+    clang::Expr *coreExpr = e->IgnoreParenCasts();
+    // если это ссылка на объявление (DeclRef)
+    if (clang::DeclRefExpr *ref =
+            clang::dyn_cast<clang::DeclRefExpr>(coreExpr)) {
+      // пытаемся превратить это в объявление переменной (VarDecl)
+      return clang::dyn_cast<clang::VarDecl>(ref->getDecl());
+    }
+    return nullptr; // если это не переменная - возвращаем пустоту
+  }
+
+  clang::ASTContext *m_context; // контекст для доступа к данным компиляции
+  std::vector<clang::VarDecl *>
+      m_allocatedVars; // список переменных, создавших ресурсы
+  std::vector<clang::VarDecl *>
+      m_deallocatedVars; // список переменных, удаливших ресурсы
+  std::set<clang::VarDecl *>
+      m_reportedVars; // набор переменных, о которых уже выдано предупреждение
+};
+
+// класс-посредник (между Action и Visitor)
+class VotincevDConsumer final : public clang::ASTConsumer {
+public:
+  explicit VotincevDConsumer(clang::ASTContext *context) : m_visitor(context) {}
+
+  // вызывается 1 раз когда весь TU полностью разобран в AST
+  void HandleTranslationUnit(clang::ASTContext &context) override {
+    // берем корень дерева (TranslationUnitDecl)
+    // и запускаме нашего Visitor m_visitor гулять по узлам
+    m_visitor.TraverseDecl(context.getTranslationUnitDecl());
+
+    // проверяем утечки после того, как обошли весь файл
+    m_visitor.checkLeaks();
+  }
+
+private:
+  VotincevDVisitor m_visitor;
+};
+
+// точка входа
+class ExampleAction final : public clang::PluginASTAction {
+public:
+  // метод создания экземпляра нашего Consumer, который будет "потреблять"
+  // дерево
+  std::unique_ptr<clang::ASTConsumer>
+  CreateASTConsumer(clang::CompilerInstance &ci, llvm::StringRef) override {
+    // отдаем компилятору наш Consumer, привязанный к текущему контексту
+    return std::make_unique<VotincevDConsumer>(&ci.getASTContext());
+  }
+
+  bool ParseArgs(const clang::CompilerInstance &ci,
+                 const std::vector<std::string> &args) override {
+    return true;
+  }
+};
+} // namespace
+
+// регистрация плагина (чтобы его видел Clang под коротким именем)
+static clang::FrontendPluginRegistry::Add<ExampleAction>
+    X("votincev_d_analyzerplugin", "Static analyzer for memory leaks and "
+                                   "resource management (malloc/new/fopen)");

--- a/clang/test/compiler-course/kutergin_valentin_3823b1fi3/test.cpp
+++ b/clang/test/compiler-course/kutergin_valentin_3823b1fi3/test.cpp
@@ -1,0 +1,25 @@
+// RUN: %clang_cc1 -fcxx-exceptions -fexceptions -load %llvmshlibdir/NoexceptSpecificatorPlugin_Kutergin_Valentin_FIIT3_ClangAST%pluginext -add-plugin kutergin_valentin_3823b1fi3 -ast-dump %s 2>&1 | FileCheck %s
+
+// Тест 1: Пустая функция должна стать noexcept
+// CHECK: FunctionDecl {{.*}} func1 'void () noexcept'
+void func1() {}
+
+// Тест 2: Функция с throw НЕ должна стать noexcept
+// CHECK: FunctionDecl {{.*}} func2 'void ()'
+// CHECK-NOT: noexcept
+void func2() { 
+    throw 1;
+}
+
+// Тест 3: Вызов опасной функции
+// CHECK: FunctionDecl {{.*}} func3 'void ()'
+// CHECK-NOT: noexcept
+void func3() {
+    func2();
+}
+
+// Тест 4: Функция с аргументами и без вызова исключений должна стать Noexcept
+// CHECK: FunctionDecl {{.*}} func4 'int (int, int) noexcept'
+int func4(int a, int b) {
+    return a + b;
+}

--- a/clang/test/compiler-course/lukin_i_test/test.cpp
+++ b/clang/test/compiler-course/lukin_i_test/test.cpp
@@ -1,0 +1,42 @@
+// RUN: %clang_cc1 -load %llvmshlibdir/VariableStatisticsPlugin_Lukin_Ivan_FIIT3_ClangAST%pluginext -plugin VariableStatisticsPlugin -fsyntax-only %s 2>&1 | FileCheck %s
+
+int global1 = 0;
+
+static int static1 = 0;
+
+class Example{
+    static int static2;
+    int nonVisible;
+};
+
+void foo1()
+{
+    int local1 = 0;
+    static int static3 = 0;
+    double local2 = 0.0;
+}
+
+double global2 = 0.0;
+
+void foo2(int param1, int param2)
+{
+    int local3 = 0;
+}
+
+namespace
+{
+    static int static4;
+    int global3;
+}
+
+void foo3(double param3, unsigned param4)
+{
+    for(int local4 = 0; local4 < 4; local4++);
+}
+
+
+// CHECK: Statistics
+// CHECK-NEXT: Global objects: 3
+// CHECK-NEXT: Local variables: 4
+// CHECK-NEXT: Static variables: 4
+// CHECK-NEXT: Params: 4

--- a/clang/test/compiler-course/romanov_a_cast_replace/test.cpp
+++ b/clang/test/compiler-course/romanov_a_cast_replace/test.cpp
@@ -1,7 +1,6 @@
+// clang-format off
 // RUN: split-file %s %t
-// RUN: %clang_cc1 -load %llvmshlibdir/romanov_a_cast_replace_ClangAST%pluginext
-// -plugin romanov_a_cast_replace_plugin -fsyntax-only %t/input.cpp 2>&1 |
-// FileCheck %s
+// RUN: %clang_cc1 -load %llvmshlibdir/romanov_a_cast_replace_ClangAST%pluginext -plugin romanov_a_cast_replace_plugin -fsyntax-only %t/input.cpp 2>&1 | FileCheck %s
 
 // CHECK-LABEL: int staticCastBase1(float a) {
 // CHECK-NEXT:     return static_cast<int>(a);
@@ -103,59 +102,154 @@
 // CHECK-NEXT:     return (reinterpret_cast<char *>((a)));
 // CHECK-NEXT: }
 
+// CHECK-LABEL: int enumToIntCast(Color c) {
+// CHECK-NEXT:     return static_cast<int>(c);
+// CHECK-NEXT: }
+
+// CHECK-LABEL: Color intToEnumCast(int a) {
+// CHECK-NEXT:     return static_cast<Color>(a);
+// CHECK-NEXT: }
+
+// CHECK-LABEL: Base *derivedToBaseCast(Derived *a) {
+// CHECK-NEXT:     return static_cast<Base *>(a);
+// CHECK-NEXT: }
+
+// CHECK-LABEL: Derived *baseToDerivedCast(Base *a) {
+// CHECK-NEXT:     return static_cast<Derived *>(a);
+// CHECK-NEXT: }
+
+// CHECK-LABEL: void castInAssignment(float a) {
+// CHECK-NEXT:     int b = static_cast<int>(a);
+// CHECK-NEXT: }
+
 //--- input.cpp
-int staticCastBase1(float a) { return (int)a; }
+int staticCastBase1(float a) {
+    return (int)a;
+}
 
+// Won't be replaced, because it is functional-style cast, not C-style cast
 int staticCastBase2(float a) {
-  // Won't be replaced, because it is functional style cast, not C-style cast
-  return int(a);
+    return int(a);
 }
 
-int staticCastBase3(float a) { return (int)(a); }
+int staticCastBase3(float a) {
+    return (int)(a);
+}
 
-int staticCastBase4(float a) { return ((int)(a)); }
+int staticCastBase4(float a) {
+    return ((int)(a));
+}
 
-long long staticCastBase5(float a) { return (long long)a; }
+long long staticCastBase5(float a) {
+    return (long long)a;
+}
 
-long long staticCastBase6(float a) { return (long long)(a); }
+long long staticCastBase6(float a) {
+    return (long long)(a);
+}
 
+// Won't be replaced, because it is already C++ style cast, not C-style cast
 int staticCastBase7(float a) {
-  // Won't be replaced, because it is already C++ style cast, not C-style cast
-  return static_cast<int>(a);
+    return static_cast<int>(a);
 }
 
-long double staticCastSeq(float a) { return (long double)(long long)a; }
+long double staticCastSeq(float a) {
+    return (long double)(long long)a;
+}
 
-double staticCastAfterOp(long long a, long long b) { return (double)(a + b); }
+double staticCastAfterOp(long long a, long long b) {
+    return (double)(a + b);
+}
 
-short staticCastSeqWithOp(long long a, char b) { return (short)((char)a + b); }
+short staticCastSeqWithOp(long long a, char b) {
+    return (short)((char)a + b);
+}
 
-bool staticCastInCondition(float a) { return (int)a > 0; }
+bool staticCastInCondition(float a) {
+    return (int)a > 0;
+}
 
-int staticCastNegative(double a) { return (int)-a; }
+int staticCastNegative(double a) {
+    return (int)-a;
+}
 
-int staticCastTernary(float a, float b) { return (int)(a > 0 ? a : b); }
+int staticCastTernary(float a, float b) {
+    return (int)(a > 0 ? a : b);
+}
 
-int *constCastBase1(const int *a) { return (int *)a; }
+int *constCastBase1(const int *a) {
+    return (int *)a;
+}
 
-const int *constCastBase2(int *a) { return (const int *)a; }
+const int *constCastBase2(int *a) {
+    return (const int *)a;
+}
 
-int *constCastBase3(const int *a) { return ((int *)(a)); }
+int *constCastBase3(const int *a) {
+    return ((int *)(a));
+}
 
-volatile int *constCastVolatile1(int *a) { return (volatile int *)a; }
+volatile int *constCastVolatile1(int *a) {
+    return (volatile int *)a;
+}
 
-int *constCastVolatile2(volatile int *a) { return (int *)a; }
+int *constCastVolatile2(volatile int *a) {
+    return (int *)a;
+}
 
-int *constCastConstVolatile(const volatile int *a) { return (int *)a; }
+int *constCastConstVolatile(const volatile int *a) {
+    return (int *)a;
+}
 
-int *reinterpretCastBase1(float *a) { return (int *)a; }
+int *reinterpretCastBase1(float *a) {
+    return (int *)a;
+}
 
-long reinterpretCastPtrToInt(int *a) { return (long)a; }
+long reinterpretCastPtrToInt(int *a) {
+    return (long)a;
+}
 
-int *reinterpretCastIntToPtr(long a) { return (int *)a; }
+int *reinterpretCastIntToPtr(long a) {
+    return (int *)a;
+}
 
-void *reinterpretCastToVoidPtr(int *a) { return (void *)a; }
+void *reinterpretCastToVoidPtr(int *a) {
+    return (void *)a;
+}
 
-int *reinterpretCastFromVoidPtr(void *a) { return (int *)a; }
+int *reinterpretCastFromVoidPtr(void *a) {
+    return (int *)a;
+}
 
-char *reinterpretCastWithParens(float *a) { return ((char *)(a)); }
+char *reinterpretCastWithParens(float *a) {
+    return ((char *)(a));
+}
+
+enum Color { Red, Green, Blue };
+
+int enumToIntCast(Color c) {
+    return (int)c;
+}
+
+Color intToEnumCast(int a) {
+    return (Color)a;
+}
+
+struct Base {
+  virtual ~Base() {}
+};
+struct Derived : Base {
+  int id;
+};
+
+Base *derivedToBaseCast(Derived *a) {
+    return (Base *)a;
+}
+
+Derived *baseToDerivedCast(Base *a) {
+    return (Derived *)a;
+}
+
+void castInAssignment(float a) {
+    int b = (int)a;
+}

--- a/clang/test/compiler-course/romanov_a_cast_replace/test.cpp
+++ b/clang/test/compiler-course/romanov_a_cast_replace/test.cpp
@@ -1,5 +1,7 @@
 // RUN: split-file %s %t
-// RUN: %clang_cc1 -load %llvmshlibdir/romanov_a_cast_replace_ClangAST%pluginext -plugin romanov_a_cast_replace_plugin -fsyntax-only %t/input.cpp 2>&1 | FileCheck %s
+// RUN: %clang_cc1 -load %llvmshlibdir/romanov_a_cast_replace_ClangAST%pluginext
+// -plugin romanov_a_cast_replace_plugin -fsyntax-only %t/input.cpp 2>&1 |
+// FileCheck %s
 
 // CHECK-LABEL: int staticCastBase1(float a) {
 // CHECK-NEXT:     return static_cast<int>(a);
@@ -102,102 +104,58 @@
 // CHECK-NEXT: }
 
 //--- input.cpp
-int staticCastBase1(float a) {
-    return (int)a;
-}
+int staticCastBase1(float a) { return (int)a; }
 
 int staticCastBase2(float a) {
-    return int(a); // Won't be replaced, because it is functional style cast, not C-style cast
+  // Won't be replaced, because it is functional style cast, not C-style cast
+  return int(a);
 }
 
-int staticCastBase3(float a) {
-    return (int)(a);
-}
+int staticCastBase3(float a) { return (int)(a); }
 
-int staticCastBase4(float a) {
-    return ((int)(a));
-}
+int staticCastBase4(float a) { return ((int)(a)); }
 
-long long staticCastBase5(float a) {
-    return (long long)a;
-}
+long long staticCastBase5(float a) { return (long long)a; }
 
-long long staticCastBase6(float a) {
-    return (long long)(a);
-}
+long long staticCastBase6(float a) { return (long long)(a); }
 
 int staticCastBase7(float a) {
-    return static_cast<int>(a); // Won't be replaced, because it is already C++ style cast, not C-style cast
+  // Won't be replaced, because it is already C++ style cast, not C-style cast
+  return static_cast<int>(a);
 }
 
-long double staticCastSeq(float a) {
-    return (long double)(long long)a;
-}
+long double staticCastSeq(float a) { return (long double)(long long)a; }
 
-double staticCastAfterOp(long long a, long long b) {
-    return (double)(a + b);
-}
+double staticCastAfterOp(long long a, long long b) { return (double)(a + b); }
 
-short staticCastSeqWithOp(long long a, char b) {
-    return (short)((char)a + b);
-}
+short staticCastSeqWithOp(long long a, char b) { return (short)((char)a + b); }
 
-bool staticCastInCondition(float a) {
-    return (int)a > 0;
-}
+bool staticCastInCondition(float a) { return (int)a > 0; }
 
-int staticCastNegative(double a) {
-    return (int)-a;
-}
+int staticCastNegative(double a) { return (int)-a; }
 
-int staticCastTernary(float a, float b) {
-    return (int)(a > 0 ? a : b);
-}
+int staticCastTernary(float a, float b) { return (int)(a > 0 ? a : b); }
 
-int *constCastBase1(const int *a) {
-    return (int *)a;
-}
+int *constCastBase1(const int *a) { return (int *)a; }
 
-const int *constCastBase2(int *a) {
-    return (const int *)a;
-}
+const int *constCastBase2(int *a) { return (const int *)a; }
 
-int *constCastBase3(const int *a) {
-    return ((int *)(a));
-}
+int *constCastBase3(const int *a) { return ((int *)(a)); }
 
-volatile int *constCastVolatile1(int *a) {
-    return (volatile int *)a;
-}
+volatile int *constCastVolatile1(int *a) { return (volatile int *)a; }
 
-int *constCastVolatile2(volatile int *a) {
-    return (int *)a;
-}
+int *constCastVolatile2(volatile int *a) { return (int *)a; }
 
-int *constCastConstVolatile(const volatile int *a) {
-    return (int *)a;
-}
+int *constCastConstVolatile(const volatile int *a) { return (int *)a; }
 
-int *reinterpretCastBase1(float *a) {
-    return (int *)a;
-}
+int *reinterpretCastBase1(float *a) { return (int *)a; }
 
-long reinterpretCastPtrToInt(int *a) {
-    return (long)a;
-}
+long reinterpretCastPtrToInt(int *a) { return (long)a; }
 
-int *reinterpretCastIntToPtr(long a) {
-    return (int *)a;
-}
+int *reinterpretCastIntToPtr(long a) { return (int *)a; }
 
-void *reinterpretCastToVoidPtr(int *a) {
-    return (void *)a;
-}
+void *reinterpretCastToVoidPtr(int *a) { return (void *)a; }
 
-int *reinterpretCastFromVoidPtr(void *a) {
-    return (int *)a;
-}
+int *reinterpretCastFromVoidPtr(void *a) { return (int *)a; }
 
-char *reinterpretCastWithParens(float *a) {
-    return ((char *)(a));
-}
+char *reinterpretCastWithParens(float *a) { return ((char *)(a)); }

--- a/clang/test/compiler-course/romanov_a_cast_replace/test.cpp
+++ b/clang/test/compiler-course/romanov_a_cast_replace/test.cpp
@@ -122,6 +122,15 @@
 // CHECK-NEXT:     int b = static_cast<int>(a);
 // CHECK-NEXT: }
 
+// CHECK-LABEL: struct MyStruct {
+// CHECK-NEXT:     int field = static_cast<int>(3.14f);
+// CHECK-NEXT:     int method(float a) {
+// CHECK-NEXT:         return static_cast<int>(a);
+// CHECK-NEXT:     }
+// CHECK-NEXT: };
+
+// CHECK-LABEL: const float B = static_cast<float>(42);
+
 //--- input.cpp
 int staticCastBase1(float a) {
     return (int)a;
@@ -253,3 +262,12 @@ Derived *baseToDerivedCast(Base *a) {
 void castInAssignment(float a) {
     int b = (int)a;
 }
+
+struct MyStruct {
+    int field = (int)3.14f;
+    int method(float a) {
+        return (int)a;
+    }
+};
+
+const float B = (float)42;

--- a/clang/test/compiler-course/romanov_a_cast_replace/test.cpp
+++ b/clang/test/compiler-course/romanov_a_cast_replace/test.cpp
@@ -1,58 +1,203 @@
-// RUN: %clang_cc1 -load %llvmshlibdir/romanov_a_cast_replace_ClangAST%pluginext -plugin romanov_a_cast_replace_plugin -fsyntax-only %s 2>&1 | FileCheck %s
+// RUN: split-file %s %t
+// RUN: %clang_cc1 -load %llvmshlibdir/romanov_a_cast_replace_ClangAST%pluginext -plugin romanov_a_cast_replace_plugin -fsyntax-only %t/input.cpp 2>&1 | FileCheck %s
 
-
-// CHECK-LABEL: int baseCast1(float a) {
+// CHECK-LABEL: int staticCastBase1(float a) {
 // CHECK-NEXT:     return static_cast<int>(a);
 // CHECK-NEXT: }
-int baseCast1(float a) {
+
+// CHECK-LABEL: int staticCastBase2(float a) {
+// CHECK-NEXT:     return int(a);
+// CHECK-NEXT: }
+
+// CHECK-LABEL: int staticCastBase3(float a) {
+// CHECK-NEXT:     return static_cast<int>((a));
+// CHECK-NEXT: }
+
+// CHECK-LABEL: int staticCastBase4(float a) {
+// CHECK-NEXT:     return (static_cast<int>((a)));
+// CHECK-NEXT: }
+
+// CHECK-LABEL: long long staticCastBase5(float a) {
+// CHECK-NEXT:     return static_cast<long long>(a);
+// CHECK-NEXT: }
+
+// CHECK-LABEL: long long staticCastBase6(float a) {
+// CHECK-NEXT:     return static_cast<long long>((a));
+// CHECK-NEXT: }
+
+// CHECK-LABEL: int staticCastBase7(float a) {
+// CHECK-NEXT:     return static_cast<int>(a);
+// CHECK-NEXT: }
+
+// CHECK-LABEL: long double staticCastSeq(float a) {
+// CHECK-NEXT:     return static_cast<long double>(static_cast<long long>(a));
+// CHECK-NEXT: }
+
+// CHECK-LABEL: double staticCastAfterOp(long long a, long long b) {
+// CHECK-NEXT:     return static_cast<double>((a + b));
+// CHECK-NEXT: }
+
+// CHECK-LABEL: short staticCastSeqWithOp(long long a, char b) {
+// CHECK-NEXT:     return static_cast<short>((static_cast<char>(a) + b));
+// CHECK-NEXT: }
+
+// CHECK-LABEL: bool staticCastInCondition(float a) {
+// CHECK-NEXT:     return static_cast<int>(a) > 0;
+// CHECK-NEXT: }
+
+// CHECK-LABEL: int staticCastNegative(double a) {
+// CHECK-NEXT:     return static_cast<int>(-a);
+// CHECK-NEXT: }
+
+// CHECK-LABEL: int staticCastTernary(float a, float b) {
+// CHECK-NEXT:     return static_cast<int>((a > 0 ? a : b));
+// CHECK-NEXT: }
+
+// CHECK-LABEL: int *constCastBase1(const int *a) {
+// CHECK-NEXT:     return const_cast<int *>(a);
+// CHECK-NEXT: }
+
+// CHECK-LABEL: const int *constCastBase2(int *a) {
+// CHECK-NEXT:     return const_cast<const int *>(a);
+// CHECK-NEXT: }
+
+// CHECK-LABEL: int *constCastBase3(const int *a) {
+// CHECK-NEXT:     return (const_cast<int *>((a)));
+// CHECK-NEXT: }
+
+// CHECK-LABEL: volatile int *constCastVolatile1(int *a) {
+// CHECK-NEXT:     return const_cast<volatile int *>(a);
+// CHECK-NEXT: }
+
+// CHECK-LABEL: int *constCastVolatile2(volatile int *a) {
+// CHECK-NEXT:     return const_cast<int *>(a);
+// CHECK-NEXT: }
+
+// CHECK-LABEL: int *constCastConstVolatile(const volatile int *a) {
+// CHECK-NEXT:     return const_cast<int *>(a);
+// CHECK-NEXT: }
+
+// CHECK-LABEL: int *reinterpretCastBase1(float *a) {
+// CHECK-NEXT:     return reinterpret_cast<int *>(a);
+// CHECK-NEXT: }
+
+// CHECK-LABEL: long reinterpretCastPtrToInt(int *a) {
+// CHECK-NEXT:     return reinterpret_cast<long>(a);
+// CHECK-NEXT: }
+
+// CHECK-LABEL: int *reinterpretCastIntToPtr(long a) {
+// CHECK-NEXT:     return reinterpret_cast<int *>(a);
+// CHECK-NEXT: }
+
+// CHECK-LABEL: void *reinterpretCastToVoidPtr(int *a) {
+// CHECK-NEXT:     return static_cast<void *>(a);
+// CHECK-NEXT: }
+
+// CHECK-LABEL: int *reinterpretCastFromVoidPtr(void *a) {
+// CHECK-NEXT:     return static_cast<int *>(a);
+// CHECK-NEXT: }
+
+// CHECK-LABEL: char *reinterpretCastWithParens(float *a) {
+// CHECK-NEXT:     return (reinterpret_cast<char *>((a)));
+// CHECK-NEXT: }
+
+//--- input.cpp
+int staticCastBase1(float a) {
     return (int)a;
 }
 
-// CHECK-LABEL: int baseCast2(float a) {
-// CHECK-NEXT:     return int(a);
-// CHECK-NEXT: }
-int baseCast2(float a) {
-    return int(a); // No replacement because it is functional-cast (not C-style cast)
+int staticCastBase2(float a) {
+    return int(a); // Won't be replaced, because it is functional style cast, not C-style cast
 }
 
-// CHECK-LABEL: int baseCast3(float a) {
-// CHECK-NEXT:     return static_cast<int>((a));
-// CHECK-NEXT: }
-int baseCast3(float a) {
+int staticCastBase3(float a) {
     return (int)(a);
 }
 
-// CHECK-LABEL: int baseCast4(float a) {
-// CHECK-NEXT:     return (static_cast<int>((a)));
-// CHECK-NEXT: }
-int baseCast4(float a) {
+int staticCastBase4(float a) {
     return ((int)(a));
 }
 
-// CHECK-LABEL: long long baseCast5(float a) {
-// CHECK-NEXT:     return static_cast<long long>(a);
-// CHECK-NEXT: }
-long long baseCast5(float a) {
+long long staticCastBase5(float a) {
     return (long long)a;
 }
 
-// CHECK-LABEL: long long baseCast6(float a) {
-// CHECK-NEXT:     return static_cast<long long>((a));
-// CHECK-NEXT: }
-long long baseCast6(float a) {
+long long staticCastBase6(float a) {
     return (long long)(a);
 }
 
-// CHECK-LABEL: int baseCast7(float a) {
-// CHECK-NEXT:     static_cast<int>(a);
-// CHECK-NEXT: }
-int baseCast7(float a) {
-    return static_cast<int>(a); // No replacement because it is C++-style cast (not C-style cast)
+int staticCastBase7(float a) {
+    return static_cast<int>(a); // Won't be replaced, because it is already C++ style cast, not C-style cast
 }
 
-// CHECK-LABEL: double baseCastAfterOp1(long long a, long long b) {
-// CHECK-NEXT:     return static_cast<double>(a + b + c);
-// CHECK-NEXT: }
-double baseCastAfterOp1(long long a, long long b) {
+long double staticCastSeq(float a) {
+    return (long double)(long long)a;
+}
+
+double staticCastAfterOp(long long a, long long b) {
     return (double)(a + b);
+}
+
+short staticCastSeqWithOp(long long a, char b) {
+    return (short)((char)a + b);
+}
+
+bool staticCastInCondition(float a) {
+    return (int)a > 0;
+}
+
+int staticCastNegative(double a) {
+    return (int)-a;
+}
+
+int staticCastTernary(float a, float b) {
+    return (int)(a > 0 ? a : b);
+}
+
+int *constCastBase1(const int *a) {
+    return (int *)a;
+}
+
+const int *constCastBase2(int *a) {
+    return (const int *)a;
+}
+
+int *constCastBase3(const int *a) {
+    return ((int *)(a));
+}
+
+volatile int *constCastVolatile1(int *a) {
+    return (volatile int *)a;
+}
+
+int *constCastVolatile2(volatile int *a) {
+    return (int *)a;
+}
+
+int *constCastConstVolatile(const volatile int *a) {
+    return (int *)a;
+}
+
+int *reinterpretCastBase1(float *a) {
+    return (int *)a;
+}
+
+long reinterpretCastPtrToInt(int *a) {
+    return (long)a;
+}
+
+int *reinterpretCastIntToPtr(long a) {
+    return (int *)a;
+}
+
+void *reinterpretCastToVoidPtr(int *a) {
+    return (void *)a;
+}
+
+int *reinterpretCastFromVoidPtr(void *a) {
+    return (int *)a;
+}
+
+char *reinterpretCastWithParens(float *a) {
+    return ((char *)(a));
 }

--- a/clang/test/compiler-course/romanov_a_cast_replace/test.cpp
+++ b/clang/test/compiler-course/romanov_a_cast_replace/test.cpp
@@ -1,0 +1,58 @@
+// RUN: %clang_cc1 -load %llvmshlibdir/romanov_a_cast_replace_ClangAST%pluginext -plugin romanov_a_cast_replace_plugin -fsyntax-only %s 2>&1 | FileCheck %s
+
+
+// CHECK-LABEL: int baseCast1(float a) {
+// CHECK-NEXT:     return static_cast<int>(a);
+// CHECK-NEXT: }
+int baseCast1(float a) {
+    return (int)a;
+}
+
+// CHECK-LABEL: int baseCast2(float a) {
+// CHECK-NEXT:     return int(a);
+// CHECK-NEXT: }
+int baseCast2(float a) {
+    return int(a); // No replacement because it is functional-cast (not C-style cast)
+}
+
+// CHECK-LABEL: int baseCast3(float a) {
+// CHECK-NEXT:     return static_cast<int>((a));
+// CHECK-NEXT: }
+int baseCast3(float a) {
+    return (int)(a);
+}
+
+// CHECK-LABEL: int baseCast4(float a) {
+// CHECK-NEXT:     return (static_cast<int>((a)));
+// CHECK-NEXT: }
+int baseCast4(float a) {
+    return ((int)(a));
+}
+
+// CHECK-LABEL: long long baseCast5(float a) {
+// CHECK-NEXT:     return static_cast<long long>(a);
+// CHECK-NEXT: }
+long long baseCast5(float a) {
+    return (long long)a;
+}
+
+// CHECK-LABEL: long long baseCast6(float a) {
+// CHECK-NEXT:     return static_cast<long long>((a));
+// CHECK-NEXT: }
+long long baseCast6(float a) {
+    return (long long)(a);
+}
+
+// CHECK-LABEL: int baseCast7(float a) {
+// CHECK-NEXT:     static_cast<int>(a);
+// CHECK-NEXT: }
+int baseCast7(float a) {
+    return static_cast<int>(a); // No replacement because it is C++-style cast (not C-style cast)
+}
+
+// CHECK-LABEL: double baseCastAfterOp1(long long a, long long b) {
+// CHECK-NEXT:     return static_cast<double>(a + b + c);
+// CHECK-NEXT: }
+double baseCastAfterOp1(long long a, long long b) {
+    return (double)(a + b);
+}

--- a/clang/test/compiler-course/votincev_d_analyzer/test.cpp
+++ b/clang/test/compiler-course/votincev_d_analyzer/test.cpp
@@ -1,0 +1,102 @@
+// RUN: split-file %s %t
+// RUN: %clang_cc1 -load %llvmshlibdir/votincev_d_analyzer_ClangAST%pluginext -plugin votincev_d_analyzerplugin -fsyntax-only -verify %t/with_warnings.cpp
+// RUN: %clang_cc1 -load %llvmshlibdir/votincev_d_analyzer_ClangAST%pluginext -plugin votincev_d_analyzerplugin -fsyntax-only -verify %t/without_warnings.cpp
+
+//--- with_warnings.cpp
+extern "C" {
+    void* malloc(unsigned long size);
+    void* fopen(const char* filename, const char* mode);
+}
+
+int* g_leak = (int*)malloc(100); 
+
+int* test_malloc_return(int sz) {
+    int* p = (int*)malloc(sz);
+    return p; // expected-warning {{Ресурс для переменной 'g_leak' может быть не освобожден (не гарантированное освобождение при return)!}} expected-warning {{Ресурс для переменной 'p' может быть не освобожден (не гарантированное освобождение при return)!}}
+}
+
+int* test_new_return(int sz) {
+    int* p = new int[sz];
+    return p; // expected-warning {{Ресурс для переменной 'p' может быть не освобожден (не гарантированное освобождение при return)!}}
+}
+
+void* test_fopen_return(const char* name) {
+    void* f = fopen(name, "r");
+    return f; // expected-warning {{Ресурс для переменной 'f' может быть не освобожден (не гарантированное освобождение при return)!}}
+}
+
+void test_branching_leak(int sz,int value) {
+    int* p = new int[sz];
+    if (value < 5) {
+        return; // expected-warning {{Ресурс для переменной 'p' может быть не освобожден (не гарантированное освобождение при return)!}}
+    }
+    delete[] p;
+}
+
+void test_nested_return(int sz) {
+    {
+        {
+            int* p_nested = (int*)malloc(sz);
+        }
+    }
+    return; // expected-warning {{Ресурс для переменной 'p_nested' может быть не освобожден (не гарантированное освобождение при return)!}}
+}
+
+void test_nested_no_return(int sz) {
+    {
+        {
+            int* p_nested = (int*)malloc(sz); // expected-warning {{Память или ресурс для переменной 'p_nested' не освобождены!}}
+        }
+    }
+}
+
+void test_malloc_no_return(int sz) {
+    int* p = (int*)malloc(sz); // expected-warning {{Память или ресурс для переменной 'p' не освобождены!}}
+}
+
+void test_new_array_no_return(int sz) {
+    int* p = new int[sz]; // expected-warning {{Память или ресурс для переменной 'p' не освобождены!}}
+}
+
+
+
+//--- without_warnings.cpp
+// expected-no-diagnostics
+extern "C" {
+    void* malloc(unsigned long size);
+    void free(void* ptr);
+    void* fopen(const char* filename, const char* mode);
+    int fclose(void* stream);
+}
+
+void test_clean_malloc(int sz) {
+    int* p = (int*)malloc(sz);
+    free(p);
+}
+
+void test_clean_new(int sz) {
+    int* p = new int[sz];
+    delete[] p;
+}
+
+void test_clean_fopen(const char* name) {
+    void* f = fopen(name, "r");
+    fclose(f);
+}
+
+void test_clean_nested(int sz) {
+    {
+        double* p = (double*)malloc(sz);
+        free(p);
+    }
+}
+
+bool test_clean_branching(int sz, int value) {
+    int* p = new int[sz];
+    if (sz > value) {
+        delete[] p;
+        return true;
+    }
+    delete[] p;
+    return false;
+}


### PR DESCRIPTION
**Формулировка задания:** Реализовать плагин, выполняющий замену C-style кастов на соответствующие C++-style касты (`static_cast`, `const_cast`, `reinterpret_cast`) в исходном коде: в телах функций, методах классов, полях классов и глобальных переменных.

**Описание реализации:** Плагин использует `RecursiveASTVisitor` для post-order обхода AST и замены каждого `CStyleCastExpr` на соответствующий C++ каст через Rewriter. Тип каста определяется по `CastKind` узла. Результат выводится в `EndSourceFileAction`.

В файле с тестами отключен clang-format (`// clang-format off`), так как тела функций сворачивались в одну строку, а FileCheck проверки разделялись на две строки, также происходило разделение не несколько строк для `// RUN: ...` ; это всё приводило к проблемам.

