### PR TITLE
Сизов Дмитрий. 3823Б1ФИ2. Вариант 4.

### DIFF
--- a/clang/compiler-course/sizov_d_lab1_var_stats_v4/CMakeLists.txt
+++ b/clang/compiler-course/sizov_d_lab1_var_stats_v4/CMakeLists.txt
@@ -1,0 +1,18 @@
+set(Title "SizovDLab1VarStatsV4Plugin")
+set(Student "Sizov_D")
+set(Group "FIIT2")
+set(TARGET_NAME "${Title}_${Student}_${Group}_ClangAST")
+
+file(GLOB_RECURSE SOURCES *.cpp *.h *.hpp)
+add_llvm_library(${TARGET_NAME} MODULE ${SOURCES} PLUGIN_TOOL clang)
+
+if(WIN32 OR CYGWIN)
+    set(LLVM_LINK_COMPONENTS Support)
+    clang_target_link_libraries(${TARGET_NAME} PRIVATE
+        clangAST
+        clangBasic
+        clangFrontend
+    )
+endif()
+
+set(CLANG_TEST_DEPS "${TARGET_NAME}" ${CLANG_TEST_DEPS} PARENT_SCOPE)

--- a/clang/compiler-course/sizov_d_lab1_var_stats_v4/sizov_d_lab1_var_stats_v4.cpp
+++ b/clang/compiler-course/sizov_d_lab1_var_stats_v4/sizov_d_lab1_var_stats_v4.cpp
@@ -1,0 +1,163 @@
+#include "clang/AST/ASTConsumer.h"
+#include "clang/AST/RecursiveASTVisitor.h"
+#include "clang/Basic/Diagnostic.h"
+#include "clang/Frontend/CompilerInstance.h"
+#include "clang/Frontend/FrontendPluginRegistry.h"
+#include "llvm/Support/Casting.h"
+#include "llvm/Support/raw_ostream.h"
+
+namespace {
+class SizovVarStatsVisitor final
+    : public clang::RecursiveASTVisitor<SizovVarStatsVisitor> {
+public:
+  explicit SizovVarStatsVisitor(clang::ASTContext &context)
+      : Context(context) {}
+
+  bool VisitVarDecl(clang::VarDecl *varDecl) {
+    if (!shouldCountDecl(varDecl) || varDecl->isImplicit()) {
+      return true;
+    }
+
+    if (llvm::isa<clang::ParmVarDecl>(varDecl)) {
+      return true;
+    }
+
+    if (!varDecl->isThisDeclarationADefinition()) {
+      return true;
+    }
+
+    noteLocation(varDecl->getLocation());
+
+    if (varDecl->isStaticLocal() || varDecl->isStaticDataMember() ||
+        (varDecl->isFileVarDecl() &&
+         varDecl->getStorageClass() == clang::SC_Static)) {
+      ++StaticCount;
+      return true;
+    }
+
+    if (varDecl->isLocalVarDecl()) {
+      ++LocalCount;
+      return true;
+    }
+
+    if (varDecl->hasGlobalStorage()) {
+      ++GlobalCount;
+    }
+
+    return true;
+  }
+
+  bool VisitParmVarDecl(clang::ParmVarDecl *parmVarDecl) {
+    if (!shouldCountDecl(parmVarDecl) || parmVarDecl->isImplicit()) {
+      return true;
+    }
+
+    const auto *func =
+        llvm::dyn_cast<clang::FunctionDecl>(parmVarDecl->getDeclContext());
+    if (!func || !func->isThisDeclarationADefinition()) {
+      return true;
+    }
+
+    noteLocation(parmVarDecl->getLocation());
+    ++ParameterCount;
+    return true;
+  }
+
+  void PrintSummary() {
+    auto &out = llvm::outs();
+    out << "Variable stats for TU:\n";
+    if (TotalCount() == 0) {
+      out << "  (no variables found)\n";
+      return;
+    }
+
+    out << "Global objects: " << GlobalCount << "\n";
+    out << "Local variables: " << LocalCount << "\n";
+    out << "Static variables: " << StaticCount << "\n";
+    out << "Function parameters: " << ParameterCount << "\n";
+    EmitSummaryWarning();
+  }
+
+private:
+  clang::ASTContext &Context;
+  unsigned GlobalCount = 0;
+  unsigned StaticCount = 0;
+  unsigned LocalCount = 0;
+  unsigned ParameterCount = 0;
+  clang::SourceLocation FirstVarLoc;
+
+  [[nodiscard]] unsigned TotalCount() const {
+    return GlobalCount + StaticCount + LocalCount + ParameterCount;
+  }
+
+  [[nodiscard]] bool shouldCountDecl(const clang::Decl *decl) const {
+    if (!decl) {
+      return false;
+    }
+
+    auto loc = decl->getLocation();
+    if (loc.isInvalid()) {
+      return false;
+    }
+
+    const auto &sm = Context.getSourceManager();
+    loc = sm.getExpansionLoc(loc);
+    return sm.isWrittenInMainFile(loc) && !sm.isInSystemHeader(loc) &&
+           !sm.isInSystemMacro(loc);
+  }
+
+  void noteLocation(clang::SourceLocation loc) {
+    if (FirstVarLoc.isValid()) {
+      return;
+    }
+
+    const auto &sm = Context.getSourceManager();
+    FirstVarLoc = sm.getExpansionLoc(loc);
+  }
+
+  void EmitSummaryWarning() {
+    auto &diag = Context.getDiagnostics();
+    const auto loc = FirstVarLoc.isValid()
+                         ? FirstVarLoc
+                         : Context.getSourceManager().getLocForStartOfFile(
+                               Context.getSourceManager().getMainFileID());
+    const unsigned diagId = diag.getCustomDiagID(
+        clang::DiagnosticsEngine::Warning,
+        "Variable stats: globals=%0 locals=%1 statics=%2 params=%3");
+    diag.Report(loc, diagId)
+        << GlobalCount << LocalCount << StaticCount << ParameterCount;
+  }
+};
+
+class SizovVarStatsConsumer final : public clang::ASTConsumer {
+public:
+  explicit SizovVarStatsConsumer(clang::ASTContext &context)
+      : Visitor(context) {}
+
+  void HandleTranslationUnit(clang::ASTContext &context) override {
+    Visitor.TraverseDecl(context.getTranslationUnitDecl());
+    Visitor.PrintSummary();
+  }
+
+private:
+  SizovVarStatsVisitor Visitor;
+};
+
+class SizovVarStatsAction final : public clang::PluginASTAction {
+public:
+  std::unique_ptr<clang::ASTConsumer>
+  CreateASTConsumer(clang::CompilerInstance &ci,
+                    llvm::StringRef /* unused */) override {
+    return std::make_unique<SizovVarStatsConsumer>(ci.getASTContext());
+  }
+
+  bool ParseArgs(const clang::CompilerInstance &,
+                 const std::vector<std::string> &) override {
+    return true;
+  }
+};
+} // namespace
+
+static clang::FrontendPluginRegistry::Add<SizovVarStatsAction>
+    X("SizovDLab1VarStatsV4Plugin_Sizov_D_FIIT2_ClangAST",
+      "Print variable statistics for the whole translation unit");

--- a/clang/test/compiler-course/sizov_d_lab1_var_stats_v4/test.cpp
+++ b/clang/test/compiler-course/sizov_d_lab1_var_stats_v4/test.cpp
@@ -1,0 +1,51 @@
+// RUN: split-file %s %t
+// RUN: %clang_cc1 -load %llvmshlibdir/SizovDLab1VarStatsV4Plugin_Sizov_D_FIIT2_ClangAST%pluginext -plugin SizovDLab1VarStatsV4Plugin_Sizov_D_FIIT2_ClangAST -fsyntax-only -verify %t/with_warnings.cpp
+// RUN: %clang_cc1 -load %llvmshlibdir/SizovDLab1VarStatsV4Plugin_Sizov_D_FIIT2_ClangAST%pluginext -plugin SizovDLab1VarStatsV4Plugin_Sizov_D_FIIT2_ClangAST -fsyntax-only -verify %t/without_warnings.cpp
+// RUN: %clang_cc1 -load %llvmshlibdir/SizovDLab1VarStatsV4Plugin_Sizov_D_FIIT2_ClangAST%pluginext -plugin SizovDLab1VarStatsV4Plugin_Sizov_D_FIIT2_ClangAST -fsyntax-only %t/with_warnings.cpp 2>&1 | FileCheck %s --check-prefix=STATS
+// RUN: %clang_cc1 -load %llvmshlibdir/SizovDLab1VarStatsV4Plugin_Sizov_D_FIIT2_ClangAST%pluginext -plugin SizovDLab1VarStatsV4Plugin_Sizov_D_FIIT2_ClangAST -fsyntax-only %t/without_warnings.cpp 2>&1 | FileCheck %s --check-prefix=EMPTY
+
+// STATS: Variable stats for TU:
+// STATS-NEXT: Global objects: 2
+// STATS-NEXT: Local variables: 3
+// STATS-NEXT: Static variables: 4
+// STATS-NEXT: Function parameters: 4
+
+// EMPTY: Variable stats for TU:
+// EMPTY-NEXT:   (no variables found)
+
+//--- with_warnings.cpp
+// expected-warning@+1 {{Variable stats: globals=2 locals=3 statics=4 params=4}}
+int GlobalA = 1;
+int GlobalB = 2;
+static int StaticGlobal = 3;
+extern int ExternOnly;
+
+class C {
+public:
+  static int StaticMember;
+};
+int C::StaticMember = 42;
+
+int foo(int x, int y) {
+  int LocalA = x + y;
+  int BlockLocal = LocalA;
+  static int StaticLocal = 0;
+  {
+    static int StaticInBlock = 0;
+    BlockLocal += StaticInBlock;
+  }
+  return BlockLocal + StaticLocal;
+}
+
+int bar(int z) {
+  int LocalB = z;
+  return LocalB;
+}
+
+int proto(int q);
+
+int baz(int p) { return p; }
+
+//--- without_warnings.cpp
+// expected-no-diagnostics
+int NoVarsHere() { return 0; }


### PR DESCRIPTION
Вывести статистику по переменным разного типа: статическим, локальным, глобальным объектам и параметрам функции (рассмотреть их отдельно от локальных переменных). Вывод должен содержать сводную статистику по всей единице трансляции (TU).