### PR TITLE
Спичек Денис 3823Б1ФИ1. Вариант 6.

### DIFF
--- a/.github/workflows/compiler-course-build.yml
+++ b/.github/workflows/compiler-course-build.yml
@@ -38,41 +38,6 @@ jobs:
             check-llvm-compiler-course \
             check-clang-compiler-course \
             check-mlir-compiler-course -j $(nproc)
-  macos-build:
-    runs-on: macOS-latest
-    strategy:
-      matrix:
-        assertions: [ON, OFF]
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-      - name: Setup environment
-        run: |
-          brew install \
-            ninja
-      - name: Setup ccache
-        uses: hendrikmuhs/ccache-action@v1.2
-        with:
-          max-size: 500M
-          key: ccache-${{ github.job }}
-      - name: Build
-        run: |
-          cmake -S llvm -B build \
-            -DCMAKE_BUILD_TYPE=Release \
-            -DLLVM_ENABLE_PROJECTS="clang;mlir" \
-            -DLLVM_ENABLE_ASSERTIONS=${{ matrix.assertions }} \
-            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
-            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-            -DLLVM_TARGETS_TO_BUILD="X86;AArch64" \
-            -G Ninja
-          cmake --build build --config Release -j $(nproc)
-      - name: Test
-        run: |
-          cmake --build build --config Release -t \
-            check-llvm-compiler-course \
-            check-clang-compiler-course \
-            check-mlir-compiler-course -j $(nproc)
   windows-build:
     runs-on: windows-latest
     strategy:

--- a/clang/compiler-course/spichek_d_virtual_functions/CMakeLists.txt
+++ b/clang/compiler-course/spichek_d_virtual_functions/CMakeLists.txt
@@ -1,0 +1,16 @@
+get_filename_component(CURRENT_DIR_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+set(TARGET_NAME "${CURRENT_DIR_NAME}_ClangAST")
+
+file(GLOB_RECURSE SOURCES *.cpp *.h *.hpp)
+add_llvm_library(${TARGET_NAME} MODULE ${SOURCES} PLUGIN_TOOL clang)
+
+if(WIN32 OR CYGWIN)
+    set(LLVM_LINK_COMPONENTS Support)
+    clang_target_link_libraries(${TARGET_NAME} PRIVATE
+        clangAST
+        clangBasic
+        clangFrontend
+    )
+endif()
+
+set(CLANG_TEST_DEPS "${TARGET_NAME}" ${CLANG_TEST_DEPS} PARENT_SCOPE)

--- a/clang/compiler-course/spichek_d_virtual_functions/example.cpp
+++ b/clang/compiler-course/spichek_d_virtual_functions/example.cpp
@@ -1,0 +1,66 @@
+#include "clang/AST/ASTConsumer.h"
+#include "clang/AST/Attr.h"
+#include "clang/AST/RecursiveASTVisitor.h"
+#include "clang/Basic/Diagnostic.h"
+#include "clang/Frontend/CompilerInstance.h"
+#include "clang/Frontend/FrontendPluginRegistry.h"
+
+namespace {
+
+class MissingOverrideVisitor final
+    : public clang::RecursiveASTVisitor<MissingOverrideVisitor> {
+public:
+  explicit MissingOverrideVisitor(clang::ASTContext *context,
+                                  clang::CompilerInstance &ci)
+      : m_context(context), m_ci(ci) {
+    m_diagID = m_ci.getDiagnostics().getCustomDiagID(
+        clang::DiagnosticsEngine::Warning,
+        "virtual function overrides a base class virtual function but is not "
+        "marked with 'override'");
+  }
+
+  bool VisitCXXMethodDecl(clang::CXXMethodDecl *MD) {
+    if (MD->size_overridden_methods() > 0) {
+      if (!MD->hasAttr<clang::OverrideAttr>()) {
+        m_ci.getDiagnostics().Report(MD->getLocation(), m_diagID);
+      }
+    }
+    return true;
+  }
+
+private:
+  clang::ASTContext *m_context;
+  clang::CompilerInstance &m_ci;
+  unsigned m_diagID;
+};
+
+class MissingOverrideConsumer final : public clang::ASTConsumer {
+public:
+  explicit MissingOverrideConsumer(clang::ASTContext *context,
+                                   clang::CompilerInstance &ci)
+      : m_visitor(context, ci) {}
+
+  void HandleTranslationUnit(clang::ASTContext &context) override {
+    m_visitor.TraverseDecl(context.getTranslationUnitDecl());
+  }
+
+private:
+  MissingOverrideVisitor m_visitor;
+};
+
+class MissingOverrideAction final : public clang::PluginASTAction {
+public:
+  std::unique_ptr<clang::ASTConsumer>
+  CreateASTConsumer(clang::CompilerInstance &ci, llvm::StringRef) override {
+    return std::make_unique<MissingOverrideConsumer>(&ci.getASTContext(), ci);
+  }
+
+  bool ParseArgs(const clang::CompilerInstance &ci,
+                 const std::vector<std::string> &args) override {
+    return true;
+  }
+};
+} // namespace
+
+static clang::FrontendPluginRegistry::Add<MissingOverrideAction>
+    X("missing_override_plugin", "Warns about missing override specifiers");

--- a/clang/test/compiler-course/spichek_d_virtual_functions/test.cpp
+++ b/clang/test/compiler-course/spichek_d_virtual_functions/test.cpp
@@ -1,0 +1,47 @@
+// RUN: %clang_cc1 -load %llvmshlibdir/spichek_d_virtual_functions_ClangAST%pluginext -plugin missing_override_plugin -fsyntax-only %s 2>&1 | FileCheck %s
+class Base {
+public:
+    virtual void doSomething();
+    virtual void doAnotherThing();
+    virtual void doVirtualThing();
+    virtual ~Base();
+};
+
+class Derived : public Base {
+public:
+    // Случай 1: Отсутствует override у обычного переопределения (должен быть warning)
+    // CHECK: [[@LINE+1]]:10: warning: virtual function overrides a base class virtual function but is not marked with 'override'
+    void doSomething();
+
+    // Случай 2: Правильное переопределение с override (warning нет)
+    void doAnotherThing() override;
+
+    // Случай 3: Указано virtual, но нет override (должен быть warning)
+    // Указание virtual не заменяет необходимость писать override
+    // CHECK: [[@LINE+1]]:18: warning: virtual function overrides a base class virtual function but is not marked with 'override'
+    virtual void doVirtualThing();
+
+    // Случай 4: Деструктор переопределяет виртуальный деструктор базы без override (должен быть warning)
+    // CHECK: [[@LINE+1]]:5: warning: virtual function overrides a base class virtual function but is not marked with 'override'
+    ~Derived();
+
+    // Случай 5: Совершенно новая виртуальная функция (warning нет)
+    virtual void newVirtualFunction();
+
+    // Случай 6: Обычная невиртуальная функция (warning нет)
+    void normalFunction();
+};
+
+class DeepDerived : public Derived {
+public:
+    // Случай 7: Глубокое наследование, пропущен override (должен быть warning)
+    // CHECK: [[@LINE+1]]:10: warning: virtual function overrides a base class virtual function but is not marked with 'override'
+    void doSomething();
+    
+    // Случай 8: Переопределение новой виртуальной функции из Derived (должен быть warning)
+    // CHECK: [[@LINE+1]]:10: warning: virtual function overrides a base class virtual function but is not marked with 'override'
+    void newVirtualFunction();
+
+    // Случай 9: Деструктор с override (warning нет)
+    ~DeepDerived() override;
+};


### PR DESCRIPTION
Вывести предупреждение для каждой виртуальной функции производного класса, которая переопределяет виртуальную функцию из базового класса, но не помечена спецификатором override