### PR TITLE
Круглова Алёна. 3823Б1ФИ2. Вариант 4

### DIFF
--- a/.github/deadline.py
+++ b/.github/deadline.py
@@ -1,35 +1,44 @@
 import os
 import sys
 from github import Github
-from datetime import datetime
+from datetime import datetime, timedelta
 from zoneinfo import ZoneInfo
 
 
 def main():
     moscow_tz = ZoneInfo("Europe/Moscow")
-    current_date = datetime.now(moscow_tz)
-    deadline_date = {
+    deadlines = {
         "lab:clang": datetime(2026, 3, 17, hour=19, tzinfo=moscow_tz),
         "lab:llvm ir": datetime(2099, 6, 1, hour=19, tzinfo=moscow_tz),
         "lab:backend": datetime(2099, 6, 1, hour=19, tzinfo=moscow_tz),
         "lab:mlir": datetime(2099, 6, 1, hour=19, tzinfo=moscow_tz),
     }
+    lab_labels = ["lab:clang", "lab:llvm ir", "lab:backend", "lab:mlir"]
 
     gh = Github(os.environ["GITHUB_TOKEN"])
     repo = gh.get_repo(os.environ["GITHUB_REPOSITORY"])
     pr = repo.get_pull(int(os.environ["PR_NUMBER"]))
-    labels = ["lab:clang", "lab:llvm ir", "lab:backend", "lab:mlir"]
-    lab_label = None
-
-    for label in pr.get_labels():
-        if label.name in labels:
-            lab_label = label.name
+    current_labels = [label.name for label in pr.get_labels()]
+    lab_label = next((l for l in current_labels if l in lab_labels), None)
 
     if not lab_label:
         return
 
-    if current_date > deadline_date[lab_label]:
-        pr.add_to_labels("delayed")
+    pr_created_date = pr.created_at.astimezone(moscow_tz)
+    current_date = datetime.now(moscow_tz)
+    deadline_date = deadlines[lab_label]
+    time_before_deadline = deadline_date - pr_created_date
+    LABEL_LOW_PRIORITY = "low priority"
+    LABEL_DELAYED = "delayed"
+
+    if current_date > deadline_date:
+        if LABEL_DELAYED not in current_labels:
+            pr.add_to_labels(LABEL_DELAYED)
+        if LABEL_LOW_PRIORITY in current_labels:
+            pr.remove_from_labels(LABEL_LOW_PRIORITY)
+    elif time_before_deadline < timedelta(hours=72):
+        if LABEL_LOW_PRIORITY not in current_labels:
+            pr.add_to_labels(LABEL_LOW_PRIORITY)
 
 
 if __name__ == "__main__":

--- a/.github/workflows/compiler-course-build.yml
+++ b/.github/workflows/compiler-course-build.yml
@@ -38,41 +38,6 @@ jobs:
             check-llvm-compiler-course \
             check-clang-compiler-course \
             check-mlir-compiler-course -j $(nproc)
-  macos-build:
-    runs-on: macOS-latest
-    strategy:
-      matrix:
-        assertions: [ON, OFF]
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-      - name: Setup environment
-        run: |
-          brew install \
-            ninja
-      - name: Setup ccache
-        uses: hendrikmuhs/ccache-action@v1.2
-        with:
-          max-size: 500M
-          key: ccache-${{ github.job }}
-      - name: Build
-        run: |
-          cmake -S llvm -B build \
-            -DCMAKE_BUILD_TYPE=Release \
-            -DLLVM_ENABLE_PROJECTS="clang;mlir" \
-            -DLLVM_ENABLE_ASSERTIONS=${{ matrix.assertions }} \
-            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
-            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-            -DLLVM_TARGETS_TO_BUILD="X86;AArch64" \
-            -G Ninja
-          cmake --build build --config Release -j $(nproc)
-      - name: Test
-        run: |
-          cmake --build build --config Release -t \
-            check-llvm-compiler-course \
-            check-clang-compiler-course \
-            check-mlir-compiler-course -j $(nproc)
   windows-build:
     runs-on: windows-latest
     strategy:

--- a/.github/workflows/compiler-course-build.yml
+++ b/.github/workflows/compiler-course-build.yml
@@ -1,6 +1,10 @@
 name: Build LLVM
 on: [push, pull_request]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/course-spring-2026' && github.event_name != 'merge_group' && !startsWith(github.ref, 'refs/heads/gh-readonly-queue') }}
+
 jobs:
   ubuntu-gcc-build:
     runs-on: ubuntu-latest

--- a/.github/workflows/compiler-course-static-analysis.yml
+++ b/.github/workflows/compiler-course-static-analysis.yml
@@ -1,0 +1,17 @@
+name: Static analysis
+on: [pull_request]
+
+jobs:
+  clang-format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Install clang-format
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang-format
+      - name: Run clang-format
+        run: |
+          git-clang-format --diff `git merge-base ${GITHUB_SHA} origin/${GITHUB_BASE_REF}`

--- a/clang/compiler-course/kruglova_a_fi2_lab1/CMakeLists.txt
+++ b/clang/compiler-course/kruglova_a_fi2_lab1/CMakeLists.txt
@@ -1,0 +1,16 @@
+get_filename_component(CURRENT_DIR_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+set(TARGET_NAME "${CURRENT_DIR_NAME}_ClangAST")
+
+file(GLOB_RECURSE SOURCES *.cpp *.h *.hpp)
+add_llvm_library(${TARGET_NAME} MODULE ${SOURCES} PLUGIN_TOOL clang)
+
+if(WIN32 OR CYGWIN)
+    set(LLVM_LINK_COMPONENTS Support)
+    clang_target_link_libraries(${TARGET_NAME} PRIVATE
+        clangAST
+        clangBasic
+        clangFrontend
+    )
+endif()
+
+set(CLANG_TEST_DEPS "${TARGET_NAME}" ${CLANG_TEST_DEPS} PARENT_SCOPE)

--- a/clang/compiler-course/kruglova_a_fi2_lab1/kruglova_lab1.cpp
+++ b/clang/compiler-course/kruglova_a_fi2_lab1/kruglova_lab1.cpp
@@ -1,0 +1,77 @@
+#include "clang/AST/ASTConsumer.h"
+#include "clang/AST/RecursiveASTVisitor.h"
+#include "clang/Frontend/CompilerInstance.h"
+#include "clang/Frontend/FrontendPluginRegistry.h"
+#include "llvm/Support/raw_ostream.h"
+
+namespace {
+
+struct Counter {
+  int globals = 0;
+  int statics = 0;
+  int locals = 0;
+  int params = 0;
+};
+
+class VarVisitorKruglova
+    : public clang::RecursiveASTVisitor<VarVisitorKruglova> {
+public:
+  Counter results;
+
+  bool VisitParmVarDecl(clang::ParmVarDecl *P) {
+    results.params++;
+    return true;
+  }
+
+  bool VisitVarDecl(clang::VarDecl *V) {
+    if (llvm::isa<clang::ParmVarDecl>(V))
+      return true;
+
+    if (V->isStaticLocal() || V->getStorageClass() == clang::SC_Static ||
+        V->isStaticDataMember()) {
+      results.statics++;
+    } else if (V->isLocalVarDecl()) {
+      results.locals++;
+    } else if (V->hasGlobalStorage()) {
+      results.globals++;
+    }
+
+    return true;
+  }
+};
+
+class VarConsumerKruglova : public clang::ASTConsumer {
+public:
+  void HandleTranslationUnit(clang::ASTContext &Ctx) override {
+    VarVisitorKruglova V;
+    V.TraverseDecl(Ctx.getTranslationUnitDecl());
+
+    int total = V.results.globals + V.results.statics + V.results.locals +
+                V.results.params;
+
+    llvm::outs() << "Statistics\n"
+                 << "Globals variables: " << V.results.globals << "\n"
+                 << "Statics variables: " << V.results.statics << "\n"
+                 << "Locals variables:  " << V.results.locals << "\n"
+                 << "Params variables:  " << V.results.params << "\n"
+                 << "Total variables:   " << total << "\n";
+  }
+};
+
+class VarActionKruglova : public clang::PluginASTAction {
+public:
+  std::unique_ptr<clang::ASTConsumer>
+  CreateASTConsumer(clang::CompilerInstance &CI, llvm::StringRef) override {
+    return std::make_unique<VarConsumerKruglova>();
+  }
+
+  bool ParseArgs(const clang::CompilerInstance &,
+                 const std::vector<std::string> &) override {
+    return true;
+  }
+};
+
+} // namespace
+
+static clang::FrontendPluginRegistry::Add<VarActionKruglova>
+    X("kruglova_plugin", "Var stats");

--- a/clang/compiler-course/kurpiakov_a_task4/CMakeLists.txt
+++ b/clang/compiler-course/kurpiakov_a_task4/CMakeLists.txt
@@ -1,0 +1,18 @@
+set(Title "VarStatPlugin")
+set(Student "Kurpiakov_Aleksei")
+set(Group "FIIT3")
+set(TARGET_NAME "${Title}_${Student}_${Group}_ClangAST")
+
+file(GLOB_RECURSE SOURCES *.cpp *.h *.hpp)
+add_llvm_library(${TARGET_NAME} MODULE ${SOURCES} PLUGIN_TOOL clang)
+
+if(WIN32 OR CYGWIN)
+    set(LLVM_LINK_COMPONENTS Support)
+    clang_target_link_libraries(${TARGET_NAME} PRIVATE
+        clangAST
+        clangBasic
+        clangFrontend
+    )
+endif()
+
+set(CLANG_TEST_DEPS "${TARGET_NAME}" ${CLANG_TEST_DEPS} PARENT_SCOPE)

--- a/clang/compiler-course/kurpiakov_a_task4/task4.cpp
+++ b/clang/compiler-course/kurpiakov_a_task4/task4.cpp
@@ -1,0 +1,87 @@
+#include "clang/AST/ASTConsumer.h"
+#include "clang/AST/Decl.h"
+#include "clang/AST/RecursiveASTVisitor.h"
+#include "clang/Frontend/CompilerInstance.h"
+#include "clang/Frontend/FrontendPluginRegistry.h"
+#include "llvm/Support/raw_ostream.h"
+
+namespace {
+class VarStatVisitor final : public clang::RecursiveASTVisitor<VarStatVisitor> {
+public:
+  explicit VarStatVisitor(clang::ASTContext *context)
+      : m_context(context), global_var_counter(0), static_var_counter(0),
+        local_var_counter(0), func_parm_counter(0) {}
+
+  bool VisitVarDecl(clang::VarDecl *var) {
+
+    if (var != var->getCanonicalDecl()) {
+      return true;
+    }
+
+    if (var->isFileVarDecl()) {
+      if (var->getStorageClass() == clang::SC_Static) {
+        static_var_counter += 1;
+      } else {
+        global_var_counter += 1;
+      }
+    } else if (var->isStaticLocal()) {
+      static_var_counter += 1;
+    } else if (var->isLocalVarDeclOrParm()) {
+      if (var->isLocalVarDecl()) {
+        local_var_counter += 1;
+      } else {
+        func_parm_counter += 1;
+      }
+    }
+
+    return true;
+  }
+
+  void print() const {
+    llvm::outs() << "Total count : "
+                 << global_var_counter + static_var_counter +
+                        local_var_counter + func_parm_counter
+                 << "\n";
+    llvm::outs() << "Global variables : " << global_var_counter << "\n";
+    llvm::outs() << "Static variables : " << static_var_counter << "\n";
+    llvm::outs() << "Local variables  : " << local_var_counter << "\n";
+    llvm::outs() << "Function params  : " << func_parm_counter << "\n";
+  }
+
+private:
+  clang::ASTContext *m_context;
+  size_t global_var_counter;
+  size_t static_var_counter;
+  size_t local_var_counter;
+  size_t func_parm_counter;
+};
+
+class VarStatConsumer final : public clang::ASTConsumer {
+public:
+  explicit VarStatConsumer(clang::ASTContext *context) : m_visitor(context) {}
+
+  void HandleTranslationUnit(clang::ASTContext &context) override {
+    m_visitor.TraverseDecl(context.getTranslationUnitDecl());
+    m_visitor.print();
+  }
+
+private:
+  VarStatVisitor m_visitor;
+};
+
+class VarStatAction final : public clang::PluginASTAction {
+public:
+  std::unique_ptr<clang::ASTConsumer>
+  CreateASTConsumer(clang::CompilerInstance &ci, llvm::StringRef) override {
+    return std::make_unique<VarStatConsumer>(&ci.getASTContext());
+  }
+
+  bool ParseArgs(const clang::CompilerInstance &ci,
+                 const std::vector<std::string> &args) override {
+    return true;
+  }
+};
+} // namespace
+
+static clang::FrontendPluginRegistry::Add<VarStatAction>
+    X("var_statistic", "Description plugin");

--- a/clang/compiler-course/kutergin_valentin_3823b1fi3/CMakeLists.txt
+++ b/clang/compiler-course/kutergin_valentin_3823b1fi3/CMakeLists.txt
@@ -1,0 +1,18 @@
+set(Title "NoexceptSpecificatorPlugin")
+set(Student "Kutergin_Valentin")
+set(Group "FIIT3")
+set(TARGET_NAME "${Title}_${Student}_${Group}_ClangAST")
+
+file(GLOB_RECURSE SOURCES *.cpp *.h *.hpp)
+add_llvm_library(${TARGET_NAME} MODULE ${SOURCES} PLUGIN_TOOL clang)
+
+if(WIN32 OR CYGWIN)
+    set(LLVM_LINK_COMPONENTS Support)
+    clang_target_link_libraries(${TARGET_NAME} PRIVATE
+        clangAST
+        clangBasic
+        clangFrontend
+    )
+endif()
+
+set(CLANG_TEST_DEPS "${TARGET_NAME}" ${CLANG_TEST_DEPS} PARENT_SCOPE)

--- a/clang/compiler-course/kutergin_valentin_3823b1fi3/source.cpp
+++ b/clang/compiler-course/kutergin_valentin_3823b1fi3/source.cpp
@@ -1,0 +1,83 @@
+#include "clang/AST/ASTConsumer.h"
+#include "clang/AST/RecursiveASTVisitor.h"
+#include "clang/Frontend/CompilerInstance.h"
+#include "clang/Frontend/FrontendPluginRegistry.h"
+#include "llvm/Support/raw_ostream.h"
+
+namespace {
+class ThrowDetector final : public clang::RecursiveASTVisitor<ThrowDetector> {
+public:
+    bool canThrow = false;
+
+    bool VisitCXXThrowExpr(clang::CXXThrowExpr *E) {
+        canThrow = true;
+        return false;
+    }
+
+    bool VisitCallExpr(clang::CallExpr *E) {
+        if (clang::FunctionDecl *Callee = E->getDirectCallee()) {
+            const auto *Proto = Callee->getType()->getAs<clang::FunctionProtoType>();
+            if (!Proto || Proto->getExceptionSpecType() == clang::EST_None) {
+                canThrow = true;
+                return false;
+            }
+        }
+        return true;
+    }
+};
+
+class NoexceptVisitor final : public clang::RecursiveASTVisitor<NoexceptVisitor> {
+public:
+    explicit NoexceptVisitor(clang::ASTContext &C) : Context(C) {}
+    
+    bool VisitFunctionDecl(clang::FunctionDecl *FD) {
+        if (!FD->hasBody())
+            return true;
+
+        const auto *FPT = FD->getType()->getAs<clang::FunctionProtoType>();
+        if (!FPT || FPT->getExceptionSpecType() != clang::EST_None)
+            return true;
+
+        ThrowDetector Detector;
+        Detector.TraverseStmt(FD->getBody());
+
+        if (!Detector.canThrow) {
+            clang::FunctionProtoType::ExtProtoInfo EPI = FPT->getExtProtoInfo();
+            EPI.ExceptionSpec.Type = clang::EST_BasicNoexcept;
+
+            clang::QualType NewType = Context.getFunctionType(FPT->getReturnType(), FPT->getParamTypes(), EPI);
+
+            FD->setType(NewType);
+        }
+        return true;
+    }
+private:
+    clang::ASTContext &Context;
+};
+
+class NoexceptConsumer final : public clang::ASTConsumer {
+public:
+    void HandleTranslationUnit(clang::ASTContext &Context) override {
+        NoexceptVisitor Visitor(Context);
+        Visitor.TraverseDecl(Context.getTranslationUnitDecl());
+    }
+};
+
+class NoexceptAction final : public clang::PluginASTAction {
+public:
+    std::unique_ptr<clang::ASTConsumer> CreateASTConsumer(clang::CompilerInstance &ci, llvm::StringRef) override {
+        return std::make_unique<NoexceptConsumer>();
+    }
+
+    bool ParseArgs(const clang::CompilerInstance &ci, const std::vector<std::string> &args) override {
+        return true;
+    }
+
+    ActionType getActionType() override {
+        return AddBeforeMainAction;
+    }
+};
+} // namespace
+
+static clang::FrontendPluginRegistry::Add<NoexceptAction> 
+    X("kutergin_valentin_3823b1fi3", "NoexceptSpecificatorPlugin");

--- a/clang/compiler-course/lukin_i_lab1/CMakeLists.txt
+++ b/clang/compiler-course/lukin_i_lab1/CMakeLists.txt
@@ -1,0 +1,18 @@
+set(Title "VariableStatisticsPlugin")
+set(Student "Lukin_Ivan")
+set(Group "FIIT3")
+set(TARGET_NAME "${Title}_${Student}_${Group}_ClangAST")
+
+file(GLOB_RECURSE SOURCES *.cpp *.h *.hpp)
+add_llvm_library(${TARGET_NAME} MODULE ${SOURCES} PLUGIN_TOOL clang)
+
+if(WIN32 OR CYGWIN)
+    set(LLVM_LINK_COMPONENTS Support)
+    clang_target_link_libraries(${TARGET_NAME} PRIVATE
+        clangAST
+        clangBasic
+        clangFrontend
+    )
+endif()
+
+set(CLANG_TEST_DEPS "${TARGET_NAME}" ${CLANG_TEST_DEPS} PARENT_SCOPE)

--- a/clang/compiler-course/lukin_i_lab1/source.cpp
+++ b/clang/compiler-course/lukin_i_lab1/source.cpp
@@ -1,0 +1,92 @@
+#include "clang/AST/ASTConsumer.h"
+#include "clang/AST/RecursiveASTVisitor.h"
+#include "clang/Frontend/CompilerInstance.h"
+#include "clang/Frontend/FrontendPluginRegistry.h"
+#include "llvm/Support/raw_ostream.h"
+
+namespace {
+
+struct Statistic // здесь будет храниться статистика по переменным
+{
+  int global_obj = 0;
+  int static_vars = 0;
+  int local_vars = 0;
+  int params = 0;
+};
+
+class StatisticVisitor final
+    : public clang::RecursiveASTVisitor<StatisticVisitor> {
+public:
+  explicit StatisticVisitor(clang::ASTContext *context)
+      : m_context(context), stat(Statistic()) {}
+
+  // вызывается, когда доходим до пар-в ф-ии
+  bool VisitParmVarDecl(clang::ParmVarDecl *D) {
+    stat.params++;
+    return true;
+  }
+
+  // вызывается, когда доходим до обьявления переменных
+  bool VisitVarDecl(clang::VarDecl *D) {
+    // т.к. пар-ры ф-ии также явл-ся переменными, проверяем, не они ли это.
+    // Иначе посчитаем дважды
+    if (clang::isa<clang::ParmVarDecl>(D)) {
+      return true;
+    }
+
+    if (D->getStorageClass() == clang::SC_Static || D->isStaticDataMember()) {
+      stat.static_vars++;
+    } else if (D->isFileVarDecl()) {
+      stat.global_obj++;
+    } else if (D->isLocalVarDecl()) {
+      stat.local_vars++;
+    }
+
+    return true;
+  }
+
+  Statistic get_statistic() const { return stat; }
+
+private:
+  clang::ASTContext *m_context;
+  Statistic stat;
+};
+
+class StatisticConsumer final : public clang::ASTConsumer {
+public:
+  explicit StatisticConsumer(clang::ASTContext *context) : m_visitor(context) {}
+
+  void HandleTranslationUnit(clang::ASTContext &context) override {
+    m_visitor.TraverseDecl(context.getTranslationUnitDecl());
+
+    Statistic stat = m_visitor.get_statistic();
+
+    auto &out = llvm::outs();
+    out << "\nStatistics\n";
+    out << "Global objects: " << stat.global_obj << "\n";
+    out << "Local variables: " << stat.local_vars << "\n";
+    out << "Static variables: " << stat.static_vars << "\n";
+    out << "Params: " << stat.params << "\n";
+  }
+
+private:
+  StatisticVisitor m_visitor;
+};
+
+class StatisticAction final : public clang::PluginASTAction {
+public:
+  std::unique_ptr<clang::ASTConsumer>
+  CreateASTConsumer(clang::CompilerInstance &ci, llvm::StringRef) override {
+    return std::make_unique<StatisticConsumer>(&ci.getASTContext());
+  }
+
+  bool ParseArgs(const clang::CompilerInstance &ci,
+                 const std::vector<std::string> &args) override {
+    return true;
+  }
+};
+} // namespace
+
+static clang::FrontendPluginRegistry::Add<StatisticAction>
+    X("VariableStatisticsPlugin",
+      "Plugin for obtaining statistics on variables in TU");

--- a/clang/compiler-course/papulina_y_noexcept_func/CMakeLists.txt
+++ b/clang/compiler-course/papulina_y_noexcept_func/CMakeLists.txt
@@ -1,0 +1,16 @@
+get_filename_component(CURRENT_DIR_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+set(TARGET_NAME "${CURRENT_DIR_NAME}_ClangAST")
+
+file(GLOB_RECURSE SOURCES *.cpp *.h *.hpp)
+add_llvm_library(${TARGET_NAME} MODULE ${SOURCES} PLUGIN_TOOL clang)
+
+if(WIN32 OR CYGWIN)
+    set(LLVM_LINK_COMPONENTS Support)
+    clang_target_link_libraries(${TARGET_NAME} PRIVATE
+        clangAST
+        clangBasic
+        clangFrontend
+    )
+endif()
+
+set(CLANG_TEST_DEPS "${TARGET_NAME}" ${CLANG_TEST_DEPS} PARENT_SCOPE)

--- a/clang/compiler-course/papulina_y_noexcept_func/analyzer.cpp
+++ b/clang/compiler-course/papulina_y_noexcept_func/analyzer.cpp
@@ -1,0 +1,141 @@
+#include "clang/AST/ASTConsumer.h"
+#include "clang/AST/RecursiveASTVisitor.h"
+#include "clang/Frontend/CompilerInstance.h"
+#include "clang/Frontend/FrontendPluginRegistry.h"
+#include "llvm/Support/raw_ostream.h"
+
+namespace {
+class FuncChecker final : public clang::RecursiveASTVisitor<FuncChecker> {
+public:
+  bool Flag = false;
+  clang::ASTContext *Context;
+  llvm::SmallPtrSet<clang::FunctionDecl *, 16> Visited;
+
+  FuncChecker(clang::ASTContext *Ctx) : Context(Ctx) {}
+  bool VisitCXXThrowExpr(clang::CXXThrowExpr *E) {
+    Flag = true;
+    return false;
+  }
+
+  bool VisitCXXNewExpr(clang::CXXNewExpr *E) {
+    Flag = true;
+    return false;
+  }
+
+  bool VisitCallExpr(clang::CallExpr *call) {
+    if (Flag)
+      return false;
+    if (clang::FunctionDecl *caller = call->getDirectCallee()) {
+      if (functionCanThrow(caller)) {
+        Flag = true;
+        return false;
+      }
+    }
+
+    return true;
+  }
+  bool VisitCXXConstructExpr(clang::CXXConstructExpr *ctor) {
+    if (Flag)
+      return false;
+
+    if (clang::CXXConstructorDecl *constructor = ctor->getConstructor()) {
+      if (functionCanThrow(constructor)) {
+        Flag = true;
+        return false;
+      }
+    }
+    return true;
+  }
+
+private:
+  bool functionCanThrow(clang::FunctionDecl *func) {
+    if (!func)
+      return false;
+
+    if (Visited.count(func))
+      return false;
+    Visited.insert(func);
+
+    const auto *ftp = func->getType()->getAs<clang::FunctionProtoType>();
+    if (ftp) {
+      if (ftp->getExceptionSpecType() == clang::EST_None) {
+        if (!func->hasBody())
+          return true;
+        FuncChecker check(Context);
+        check.Visited = Visited;
+        check.TraverseStmt(func->getBody());
+        Visited = check.Visited;
+        return check.Flag;
+      }
+    }
+
+    return false;
+  }
+};
+class PapulinaYVisitor final
+    : public clang::RecursiveASTVisitor<PapulinaYVisitor> {
+public:
+  explicit PapulinaYVisitor(clang::ASTContext *context) : m_context(context) {}
+  bool VisitFunctionDecl(clang::FunctionDecl *func) {
+    if (!func->hasBody()) {
+      return true;
+    }
+    const auto *ftp = func->getType()->getAs<clang::FunctionProtoType>();
+    if (!ftp) {
+      return true;
+    }
+    if (ftp->getExceptionSpecType() != clang::EST_None) {
+      return true;
+    }
+    FuncChecker check(m_context);
+    check.TraverseStmt(func->getBody());
+    if (!check.Flag) {
+      clang::FunctionProtoType::ExtProtoInfo epi = ftp->getExtProtoInfo();
+      epi.ExceptionSpec.Type = clang::EST_BasicNoexcept;
+
+      clang::QualType newType = m_context->getFunctionType(
+          ftp->getReturnType(), ftp->getParamTypes(), epi);
+      func->setType(newType);
+    }
+    const auto *newFtp = func->getType()->getAs<clang::FunctionProtoType>();
+    llvm::outs() << "Function " << func->getNameAsString()
+                 << ": exception spec: " << newFtp->getExceptionSpecType()
+                 << "\n";
+    return true;
+  }
+
+private:
+  clang::ASTContext *m_context;
+};
+
+class PapulinaYConsumer final : public clang::ASTConsumer {
+public:
+  explicit PapulinaYConsumer(clang::ASTContext *context) : m_visitor(context) {}
+
+  void HandleTranslationUnit(clang::ASTContext &context) override {
+    m_visitor.TraverseDecl(context.getTranslationUnitDecl());
+  }
+
+private:
+  PapulinaYVisitor m_visitor;
+};
+
+class PapulinaYAction final : public clang::PluginASTAction {
+public:
+  std::unique_ptr<clang::ASTConsumer>
+  CreateASTConsumer(clang::CompilerInstance &ci, llvm::StringRef) override {
+    return std::make_unique<PapulinaYConsumer>(&ci.getASTContext());
+  }
+
+  bool ParseArgs(const clang::CompilerInstance &ci,
+                 const std::vector<std::string> &args) override {
+    return true;
+  }
+  ActionType getActionType() override { return AddBeforeMainAction; }
+};
+} // namespace
+
+static clang::FrontendPluginRegistry::Add<PapulinaYAction>
+    X("papulina_y_noexcept_func_plugin",
+      "Adds the noexcept specifier to all functions that do not throw "
+      "exceptions");

--- a/clang/compiler-course/votincev_d_analyzer/CMakeLists.txt
+++ b/clang/compiler-course/votincev_d_analyzer/CMakeLists.txt
@@ -1,0 +1,16 @@
+get_filename_component(CURRENT_DIR_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+set(TARGET_NAME "${CURRENT_DIR_NAME}_ClangAST")
+
+file(GLOB_RECURSE SOURCES *.cpp *.h *.hpp)
+add_llvm_library(${TARGET_NAME} MODULE ${SOURCES} PLUGIN_TOOL clang)
+
+if(WIN32 OR CYGWIN)
+    set(LLVM_LINK_COMPONENTS Support)
+    clang_target_link_libraries(${TARGET_NAME} PRIVATE
+        clangAST
+        clangBasic
+        clangFrontend
+    )
+endif()
+
+set(CLANG_TEST_DEPS "${TARGET_NAME}" ${CLANG_TEST_DEPS} PARENT_SCOPE)

--- a/clang/compiler-course/votincev_d_analyzer/votincev_d_analyzer.cpp
+++ b/clang/compiler-course/votincev_d_analyzer/votincev_d_analyzer.cpp
@@ -1,0 +1,224 @@
+#include "clang/AST/ASTConsumer.h"
+#include "clang/AST/RecursiveASTVisitor.h"
+#include "clang/Frontend/CompilerInstance.h"
+#include "clang/Frontend/FrontendPluginRegistry.h"
+#include "llvm/Support/raw_ostream.h"
+
+#include <set>
+#include <vector>
+
+// работа плагина:
+// Action (создает) -> Consumer(запускает) -> Visitor(анализирует)
+
+namespace {
+
+// класс VotincevDVisitor - анализатор
+// просматривает узлы дерева
+class VotincevDVisitor final
+    : public clang::RecursiveASTVisitor<VotincevDVisitor> {
+public:
+  explicit VotincevDVisitor(clang::ASTContext *context) : m_context(context) {}
+
+  // находим ресурсы, которые не гарантированно освобождаются при выходе
+  bool VisitReturnStmt(clang::ReturnStmt *ret) {
+    for (auto *allocVar : m_allocatedVars) {
+      bool found = false;
+      for (auto *deallocVar : m_deallocatedVars) {
+        if (allocVar == deallocVar) {
+          found = true;
+          break;
+        }
+      }
+
+      // если на момент return переменная не в списке освобожденных
+      // и мы о ней еще не сообщали
+      if (!found && m_reportedVars.find(allocVar) == m_reportedVars.end()) {
+        clang::DiagnosticsEngine &DE = m_context->getDiagnostics();
+        unsigned diagID = DE.getCustomDiagID(
+            clang::DiagnosticsEngine::Warning,
+            "Ресурс для переменной '%0' может быть не освобожден (не "
+            "гарантированное освобождение при return)!");
+        DE.Report(ret->getReturnLoc(), diagID) << allocVar->getNameAsString();
+
+        m_reportedVars.insert(allocVar);
+      }
+    }
+    return true;
+  }
+
+  // функция free/fclose?
+  bool VisitCallExpr(clang::CallExpr *call) {
+    clang::FunctionDecl *func = call->getDirectCallee();
+
+    // проверяем, что это не какой-нибудь странный вызов по указателю
+    if (!func) {
+      return true;
+    }
+
+    llvm::StringRef funcName = func->getName();
+    if (funcName == "free" || funcName == "fclose") {
+      clang::Expr *arg = call->getArg(0)->IgnoreParenCasts();
+
+      clang::VarDecl *var = getVarDeclFromExpr(arg);
+
+      // если нашли переменную
+      if (var) {
+        m_deallocatedVars.push_back(var);
+      }
+    }
+
+    return true;
+  }
+
+  bool VisitCXXDeleteExpr(clang::CXXDeleteExpr *del) {
+    clang::Expr *arg = del->getArgument()->IgnoreParenCasts();
+    clang::VarDecl *var = getVarDeclFromExpr(arg);
+    if (var) {
+      m_deallocatedVars.push_back(var);
+    }
+    return true;
+  }
+
+  bool VisitVarDecl(clang::VarDecl *var) {
+    clang::Expr *init = var->getInit();
+    // если инициализация есть и это выделение памяти (malloc/new)
+    if (init && isAllocation(init)) {
+      // Проверка на уникальность, чтобы не дублировать глобальные/локальные
+      if (std::find(m_allocatedVars.begin(), m_allocatedVars.end(), var) ==
+          m_allocatedVars.end()) {
+        m_allocatedVars.push_back(var);
+      }
+    }
+    return true;
+  }
+
+  bool VisitBinaryOperator(clang::BinaryOperator *op) {
+    // если это операция присваивания и справа стоит выделение памяти
+    if (op->isAssignmentOp() && isAllocation(op->getRHS())) {
+      clang::VarDecl *var = getVarDeclFromExpr(op->getLHS());
+      if (var) {
+        // если этой переменной еще нет в списке выделенных - добавляем
+        if (std::find(m_allocatedVars.begin(), m_allocatedVars.end(), var) ==
+            m_allocatedVars.end()) {
+          m_allocatedVars.push_back(var);
+        }
+      }
+    }
+    return true;
+  }
+
+  // функция для сравнения списков и вывода предупреждений
+  void checkLeaks() {
+    for (auto *allocVar : m_allocatedVars) {
+      // если мы уже ругались на эту переменную в VisitReturnStmt — пропускаем
+      if (m_reportedVars.count(allocVar))
+        continue;
+
+      bool found = false; // флаг: нашли ли удаление
+
+      for (auto *deallocVar : m_deallocatedVars) {
+        if (allocVar == deallocVar) {
+          found = true; // нашли, значит утечки нет
+          break;
+        }
+      }
+
+      // если дошли до конца и удаления не нашли
+      if (!found) {
+        clang::DiagnosticsEngine &DE = m_context->getDiagnostics();
+        unsigned diagID = DE.getCustomDiagID(
+            clang::DiagnosticsEngine::Warning,
+            "Память или ресурс для переменной '%0' не освобождены!");
+        DE.Report(allocVar->getLocation(), diagID)
+            << allocVar->getNameAsString();
+      }
+    }
+  }
+
+private:
+  // проверяет, является ли выражение выделением
+  bool isAllocation(clang::Expr *e) {
+    if (!e)
+      return false;
+    clang::Expr *coreExpr = e->IgnoreParenCasts();
+
+    // проверка на вызов функции (malloc/fopen)
+    if (clang::CallExpr *call = clang::dyn_cast<clang::CallExpr>(coreExpr)) {
+      if (clang::FunctionDecl *func = call->getDirectCallee()) {
+        llvm::StringRef funcName = func->getName();
+        return (funcName == "malloc" || funcName == "fopen");
+      }
+    }
+
+    // проверка на оператор new
+    if (clang::isa<clang::CXXNewExpr>(coreExpr)) {
+      return true;
+    }
+
+    return false;
+  }
+
+  // достает VarDecl из любого выражения (ссылки)
+  clang::VarDecl *getVarDeclFromExpr(clang::Expr *e) {
+    if (!e)
+      return nullptr;
+    clang::Expr *coreExpr = e->IgnoreParenCasts();
+    // если это ссылка на объявление (DeclRef)
+    if (clang::DeclRefExpr *ref =
+            clang::dyn_cast<clang::DeclRefExpr>(coreExpr)) {
+      // пытаемся превратить это в объявление переменной (VarDecl)
+      return clang::dyn_cast<clang::VarDecl>(ref->getDecl());
+    }
+    return nullptr; // если это не переменная - возвращаем пустоту
+  }
+
+  clang::ASTContext *m_context; // контекст для доступа к данным компиляции
+  std::vector<clang::VarDecl *>
+      m_allocatedVars; // список переменных, создавших ресурсы
+  std::vector<clang::VarDecl *>
+      m_deallocatedVars; // список переменных, удаливших ресурсы
+  std::set<clang::VarDecl *>
+      m_reportedVars; // набор переменных, о которых уже выдано предупреждение
+};
+
+// класс-посредник (между Action и Visitor)
+class VotincevDConsumer final : public clang::ASTConsumer {
+public:
+  explicit VotincevDConsumer(clang::ASTContext *context) : m_visitor(context) {}
+
+  // вызывается 1 раз когда весь TU полностью разобран в AST
+  void HandleTranslationUnit(clang::ASTContext &context) override {
+    // берем корень дерева (TranslationUnitDecl)
+    // и запускаме нашего Visitor m_visitor гулять по узлам
+    m_visitor.TraverseDecl(context.getTranslationUnitDecl());
+
+    // проверяем утечки после того, как обошли весь файл
+    m_visitor.checkLeaks();
+  }
+
+private:
+  VotincevDVisitor m_visitor;
+};
+
+// точка входа
+class ExampleAction final : public clang::PluginASTAction {
+public:
+  // метод создания экземпляра нашего Consumer, который будет "потреблять"
+  // дерево
+  std::unique_ptr<clang::ASTConsumer>
+  CreateASTConsumer(clang::CompilerInstance &ci, llvm::StringRef) override {
+    // отдаем компилятору наш Consumer, привязанный к текущему контексту
+    return std::make_unique<VotincevDConsumer>(&ci.getASTContext());
+  }
+
+  bool ParseArgs(const clang::CompilerInstance &ci,
+                 const std::vector<std::string> &args) override {
+    return true;
+  }
+};
+} // namespace
+
+// регистрация плагина (чтобы его видел Clang под коротким именем)
+static clang::FrontendPluginRegistry::Add<ExampleAction>
+    X("votincev_d_analyzerplugin", "Static analyzer for memory leaks and "
+                                   "resource management (malloc/new/fopen)");

--- a/clang/test/compiler-course/kruglova_a_fi2_lab1/test.cpp
+++ b/clang/test/compiler-course/kruglova_a_fi2_lab1/test.cpp
@@ -1,0 +1,86 @@
+// RUN: %clang_cc1 -load %llvmshlibdir/kruglova_a_fi2_lab1_ClangAST%pluginext -plugin kruglova_plugin -fsyntax-only %s 2>&1 | FileCheck %s
+
+int g_1;
+
+namespace Data {
+  int g_namespace;
+}
+
+ static int s_1;  //глобальная static - static
+
+namespace Extra {
+  static int ns_static = 10;
+}
+struct MyStruct {
+  static int s_2;
+};
+
+void test_func(int p1, char p2) {
+
+  int l_1 = 10;
+
+  static int s_3 = 5;
+
+  for (int i = 0; i < 10; ++i) {     // i в for - locals
+    int l_2 = i;
+  }
+
+  if (int status = p1; status > 0) {    // в if-init - local
+    int l_inner = 1;
+  }
+}
+
+
+void loop_case() {
+  int x = 0;
+
+  while (int w = x++) {    // w объявлена в while - local
+    int inner = w;
+  }
+}
+
+auto lambda = [](int p_lambda) {
+  int l_lambda = 100;                // локальная внутри лямбды
+};
+
+void lambda_test() {
+
+  auto inner_lambda = [](double p_l) {
+    int l_inside = 0;
+  };
+
+}
+
+void switch_case(int p) {
+
+  switch (p) {
+
+    case 1: {
+      int local_switch = 5;   // local в switch
+      break;
+    }
+
+    default:
+      break;
+  }
+}
+
+void block_scope() {
+  {
+    int deep_local = 1;
+  }
+}
+
+
+// Globals: 3 (g_1, g_namespace, lambda)
+// Statics: 4 (s_1, ns_static, s_2, s_3)
+// Locals:  13 (l_1, i, l_2, status, l_inner, x, w, inner, l_lambda, inner_lambda, l_inside, local_switch, deep_local)
+// Params:  5 (p1, p2, p_lambda, p_l, p)
+// Total:   25
+
+// CHECK: Statistics
+// CHECK-NEXT: Globals variables: 3
+// CHECK-NEXT: Statics variables: 4
+// CHECK-NEXT: Locals variables:  13   
+// CHECK-NEXT: Params variables:  5
+// CHECK-NEXT: Total variables:   25   

--- a/clang/test/compiler-course/kurpiakov_a_AST_tests/test.cpp
+++ b/clang/test/compiler-course/kurpiakov_a_AST_tests/test.cpp
@@ -1,0 +1,95 @@
+// RUN: %clang_cc1 -load %llvmshlibdir/VarStatPlugin_Kurpiakov_Aleksei_FIIT3_ClangAST%pluginext -plugin var_statistic -fsyntax-only %s 2>&1 | FileCheck %s
+
+//CHECK: Total count : 27
+//CHECK-NEXT: Global variables : 9
+//CHECK-NEXT: Static variables : 8
+//CHECK-NEXT: Local variables  : 5
+//CHECK-NEXT: Function params  : 5
+
+static int x = 0; //  static var count = 0 + 1
+long y = 0L; //  global var count = 0 + 1
+
+
+namespace N {
+    extern int n; // +1 к global var count 
+    static int f; // +1 к static var count
+}
+
+namespace Z {
+    extern int n; // +1 к global var count тк разные namespace
+    static int f; // +1 к static var count тк разные namespace
+}
+
+namespace {
+    extern int n; // +1 к global var count тк разные namespace
+    static int f; // +1 к static var count тк разные namespace
+
+}
+
+namespace {
+    int n; // не посчитается, тк переменная была объявлена выше в том же (анонимном) namespace
+}
+
+
+namespace X {
+    int n; // +1 к global var count тк разные namespace
+    extern int n; // не посчитается, тк переменная была объявлена выше в том же namespace
+}
+
+extern int g; // +1 к global var count 
+int g; // не посчитается, тк переменная была объявлена выше
+
+template<typename Y> // все что связанно с полями класса не входит в VarDecl, а является FieldDecl
+class Class{
+public:
+    Class(): a(0), k(0) {}
+    int a;
+    Y k;
+};
+
+struct Struct{ // все что связанно с полями класса/структуры не входит в VarDecl, а является FieldDecl
+public:
+    Struct(int num = 0): a(0), k(0) {} // func parm count = 0 + 1
+    int a;
+    double k;
+};
+
+template<typename T> 
+T foo(T a, T b){ // func parm count = 1 + 2
+    static int z = 52; // static var count = 4 + 1
+    return z;
+}
+
+
+template<typename T = char>
+char foo(int a, int b){ //func parm count = 3 + 2
+    int z = 42 + static_cast<char>(x) + static_cast<char>(y); // local var count = 0 + 1
+    return z;
+}
+
+int a, b, c; // global var count = 6 + 3
+
+int main(){
+
+    static Class<int> c_int; // static var count = 5 + 1
+    Class<float> c_float; // local var count = 1 + 1
+
+    Struct st; // local var count = 2 + 1
+    
+    char z = foo(a, b); // local var count = 3 + 1
+    
+    static constexpr int var = 52; // static var count = 6 + 1
+    constexpr float var_f = 0.0f;  // local var count = 4 + 1
+    
+    static int var2  = 52; // static var count = 7 + 1
+    
+    return 0;
+}
+
+/*
+total count = 27
+global var count = 9
+static var count = 8
+local var count = 5
+func parm count = 5
+*/ 

--- a/clang/test/compiler-course/kutergin_valentin_3823b1fi3/test.cpp
+++ b/clang/test/compiler-course/kutergin_valentin_3823b1fi3/test.cpp
@@ -1,0 +1,25 @@
+// RUN: %clang_cc1 -fcxx-exceptions -fexceptions -load %llvmshlibdir/NoexceptSpecificatorPlugin_Kutergin_Valentin_FIIT3_ClangAST%pluginext -add-plugin kutergin_valentin_3823b1fi3 -ast-dump %s 2>&1 | FileCheck %s
+
+// Тест 1: Пустая функция должна стать noexcept
+// CHECK: FunctionDecl {{.*}} func1 'void () noexcept'
+void func1() {}
+
+// Тест 2: Функция с throw НЕ должна стать noexcept
+// CHECK: FunctionDecl {{.*}} func2 'void ()'
+// CHECK-NOT: noexcept
+void func2() { 
+    throw 1;
+}
+
+// Тест 3: Вызов опасной функции
+// CHECK: FunctionDecl {{.*}} func3 'void ()'
+// CHECK-NOT: noexcept
+void func3() {
+    func2();
+}
+
+// Тест 4: Функция с аргументами и без вызова исключений должна стать Noexcept
+// CHECK: FunctionDecl {{.*}} func4 'int (int, int) noexcept'
+int func4(int a, int b) {
+    return a + b;
+}

--- a/clang/test/compiler-course/lukin_i_test/test.cpp
+++ b/clang/test/compiler-course/lukin_i_test/test.cpp
@@ -1,0 +1,42 @@
+// RUN: %clang_cc1 -load %llvmshlibdir/VariableStatisticsPlugin_Lukin_Ivan_FIIT3_ClangAST%pluginext -plugin VariableStatisticsPlugin -fsyntax-only %s 2>&1 | FileCheck %s
+
+int global1 = 0;
+
+static int static1 = 0;
+
+class Example{
+    static int static2;
+    int nonVisible;
+};
+
+void foo1()
+{
+    int local1 = 0;
+    static int static3 = 0;
+    double local2 = 0.0;
+}
+
+double global2 = 0.0;
+
+void foo2(int param1, int param2)
+{
+    int local3 = 0;
+}
+
+namespace
+{
+    static int static4;
+    int global3;
+}
+
+void foo3(double param3, unsigned param4)
+{
+    for(int local4 = 0; local4 < 4; local4++);
+}
+
+
+// CHECK: Statistics
+// CHECK-NEXT: Global objects: 3
+// CHECK-NEXT: Local variables: 4
+// CHECK-NEXT: Static variables: 4
+// CHECK-NEXT: Params: 4

--- a/clang/test/compiler-course/test.cpp
+++ b/clang/test/compiler-course/test.cpp
@@ -1,0 +1,64 @@
+// RUN: %clang_cc1 -fcxx-exceptions -fexceptions -load %llvmshlibdir/papulina_y_noexcept_func_ClangAST%pluginext -add-plugin papulina_y_noexcept_func_plugin -fsyntax-only %s 2>&1 | FileCheck %s
+void goodFunc() {
+  int x = 15;
+}
+void funcWithThrow() { throw 42; }
+
+void funcWithThrowAndConditions() {
+    int x = 15;
+    if (x > 0) {
+        throw x;
+    }
+}
+
+void callFuncWithExcept() {
+    funcWithThrow();
+}
+
+void callFuncWithoutExcept() {
+    goodFunc();
+}
+
+void funcWithNew() {
+  int * ptr = new int{15};
+  delete ptr;
+}
+
+void level3() { throw 15; }
+void level2() { level3(); }  
+void level1() { level2(); }
+
+void process() {
+    funcWithThrow();
+    funcWithThrow();
+    funcWithThrow();
+}
+
+void recursiveWithThrow(int n) {
+    if (n > 0) {
+        if (n == 15) throw n; 
+        recursiveWithThrow(n - 1);
+    }
+}
+
+class TestClass {
+public:
+    TestClass() { throw 42; } 
+};
+void createObject() {
+    TestClass obj; 
+}
+
+// CHECK: Function goodFunc: exception spec: 5
+// CHECK: Function funcWithThrow: exception spec: 0
+// CHECK: Function funcWithThrowAndConditions: exception spec: 0
+// CHECK: Function callFuncWithExcept: exception spec: 0
+// CHECK: Function callFuncWithoutExcept: exception spec: 5
+// CHECK: Function funcWithNew: exception spec: 0
+// CHECK: Function level3: exception spec: 0
+// CHECK: Function level2: exception spec: 0
+// CHECK: Function level1: exception spec: 0
+// CHECK: Function process: exception spec: 0
+// CHECK: Function recursiveWithThrow: exception spec: 0
+// CHECK: Function TestClass: exception spec: 0
+// CHECK: Function createObject: exception spec: 0

--- a/clang/test/compiler-course/votincev_d_analyzer/test.cpp
+++ b/clang/test/compiler-course/votincev_d_analyzer/test.cpp
@@ -1,0 +1,102 @@
+// RUN: split-file %s %t
+// RUN: %clang_cc1 -load %llvmshlibdir/votincev_d_analyzer_ClangAST%pluginext -plugin votincev_d_analyzerplugin -fsyntax-only -verify %t/with_warnings.cpp
+// RUN: %clang_cc1 -load %llvmshlibdir/votincev_d_analyzer_ClangAST%pluginext -plugin votincev_d_analyzerplugin -fsyntax-only -verify %t/without_warnings.cpp
+
+//--- with_warnings.cpp
+extern "C" {
+    void* malloc(unsigned long size);
+    void* fopen(const char* filename, const char* mode);
+}
+
+int* g_leak = (int*)malloc(100); 
+
+int* test_malloc_return(int sz) {
+    int* p = (int*)malloc(sz);
+    return p; // expected-warning {{Ресурс для переменной 'g_leak' может быть не освобожден (не гарантированное освобождение при return)!}} expected-warning {{Ресурс для переменной 'p' может быть не освобожден (не гарантированное освобождение при return)!}}
+}
+
+int* test_new_return(int sz) {
+    int* p = new int[sz];
+    return p; // expected-warning {{Ресурс для переменной 'p' может быть не освобожден (не гарантированное освобождение при return)!}}
+}
+
+void* test_fopen_return(const char* name) {
+    void* f = fopen(name, "r");
+    return f; // expected-warning {{Ресурс для переменной 'f' может быть не освобожден (не гарантированное освобождение при return)!}}
+}
+
+void test_branching_leak(int sz,int value) {
+    int* p = new int[sz];
+    if (value < 5) {
+        return; // expected-warning {{Ресурс для переменной 'p' может быть не освобожден (не гарантированное освобождение при return)!}}
+    }
+    delete[] p;
+}
+
+void test_nested_return(int sz) {
+    {
+        {
+            int* p_nested = (int*)malloc(sz);
+        }
+    }
+    return; // expected-warning {{Ресурс для переменной 'p_nested' может быть не освобожден (не гарантированное освобождение при return)!}}
+}
+
+void test_nested_no_return(int sz) {
+    {
+        {
+            int* p_nested = (int*)malloc(sz); // expected-warning {{Память или ресурс для переменной 'p_nested' не освобождены!}}
+        }
+    }
+}
+
+void test_malloc_no_return(int sz) {
+    int* p = (int*)malloc(sz); // expected-warning {{Память или ресурс для переменной 'p' не освобождены!}}
+}
+
+void test_new_array_no_return(int sz) {
+    int* p = new int[sz]; // expected-warning {{Память или ресурс для переменной 'p' не освобождены!}}
+}
+
+
+
+//--- without_warnings.cpp
+// expected-no-diagnostics
+extern "C" {
+    void* malloc(unsigned long size);
+    void free(void* ptr);
+    void* fopen(const char* filename, const char* mode);
+    int fclose(void* stream);
+}
+
+void test_clean_malloc(int sz) {
+    int* p = (int*)malloc(sz);
+    free(p);
+}
+
+void test_clean_new(int sz) {
+    int* p = new int[sz];
+    delete[] p;
+}
+
+void test_clean_fopen(const char* name) {
+    void* f = fopen(name, "r");
+    fclose(f);
+}
+
+void test_clean_nested(int sz) {
+    {
+        double* p = (double*)malloc(sz);
+        free(p);
+    }
+}
+
+bool test_clean_branching(int sz, int value) {
+    int* p = new int[sz];
+    if (sz > value) {
+        delete[] p;
+        return true;
+    }
+    delete[] p;
+    return false;
+}


### PR DESCRIPTION
Разработан плагин для компилятора Clang, выполняющий обход AST исходного кода и подсчёт количества глобальных, статических, локальных переменных и параметров функций. Результатом работы плагина является вывод сводной статистики по единице трансляции, корректность которой подтверждена тестовым файлом.